### PR TITLE
Issue/#7 - Ignoring whitespaces on properties names on template is now possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
-            <version>0.8.16</version>
+            <version>0.9.4</version>
         </dependency>
         <dependency>
             <groupId>redis.clients</groupId>

--- a/src/main/java/com/vsct/dt/hesperides/resources/Valorisation.java
+++ b/src/main/java/com/vsct/dt/hesperides/resources/Valorisation.java
@@ -23,30 +23,41 @@ package com.vsct.dt.hesperides.resources;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+import org.apache.commons.lang.NotImplementedException;
 
 import java.io.IOException;
 import java.util.Map;
 
 /**
  * Created by william_montaz on 28/07/2015.
+ * Updated by Tidiane SIDIBE on 09/11/2016 : Add whitespaces ignoring on properties name
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonDeserialize(using = Valorisation.JacksonDeserializer.class)
 /* Cannot use abstract class because of jackson throwing a "cannot find JsonCreator for property exception*/
 public class Valorisation {
 
+    /**
+     * The valuation's name.
+     * Note : This is foreight key like for joining model and valuation.
+     */
     private String name;
 
+    /**
+     * The
+     * @param name: the name of the valuation
+     */
     @JsonCreator
     protected Valorisation(@JsonProperty("name") final String name) {
-        this.name = name;
+
+        // We trim this for ignore whitespaces on valuation's name.
+        // The same operation is done on property model's name.
+        this.name = name.trim();
     }
 
     @JsonProperty("name")
@@ -56,12 +67,19 @@ public class Valorisation {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Valorisation that = (Valorisation) o;
 
-        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) {
+            return false;
+        }
 
         return true;
     }
@@ -73,7 +91,7 @@ public class Valorisation {
 
     public Valorisation inject(Map<String, String> keyValueProperties){
         throw new NotImplementedException();
-    };
+    }
 
     /* Use a specific deserializer to handle polymorphism and avoid changing the existing API */
     public static class JacksonDeserializer extends StdDeserializer<Valorisation> {
@@ -83,7 +101,7 @@ public class Valorisation {
         }
 
         @Override
-        public Valorisation deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        public Valorisation deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
             ObjectMapper mapper = (ObjectMapper) jp.getCodec();
             ObjectNode obj = mapper.readTree(jp);
 

--- a/src/main/java/com/vsct/dt/hesperides/templating/models/Property.java
+++ b/src/main/java/com/vsct/dt/hesperides/templating/models/Property.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 
 /**
  * Created by william_montaz on 11/07/14.
+ * Updated by Tidiane SIDIBE on 09/11/2016 : Add whitespaces ignoring on properties name
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"name", "comment", "required", "defaultValue", "pattern"})
@@ -54,6 +55,10 @@ public class Property {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Property.class);
 
+    /**
+     * Constructor from mustache codes
+     * @param code : mustache code
+     */
     public Property(final DefaultCode code) {
         /* Bad but no other way for now */
         /* TO DO BIG WARNING */
@@ -63,10 +68,10 @@ public class Property {
             String nameAndCommentString = (String) f.get(code);
             String[] fields = nameAndCommentString.split("[|]", 2);
 
-            // We trim the name : Hesperides should ignore tabs, whitespaces on property names
-            // Triming this is very dangerous, we need to see more further of avoiding values lost
-            // Already existing values are not retrieved correctly
-            this.name = fields[0];
+            // We trim this for letting hesperides ignore the whitespaces on properties in the templates
+            // Ex. {{ db.user.login  }} should be treated as {{db.user.login}}
+            // This has impact to valorsiation's name and mustach templates
+            this.name = fields[0].trim();
 
             // Second field can be comment (old way) or annotation (new way).
             if (fields.length > 1) {
@@ -129,10 +134,21 @@ public class Property {
         }
     }
 
+    /**
+     * Constructor from name and comment
+     * Ex. {{hello|I am the comment}}
+     *
+     * @param name : the name
+     * @param comment : the comment
+     */
     @JsonCreator
     public Property(@JsonProperty("name") final String name,
                     @JsonProperty("comment") final String comment) {
-        this.name = name;
+
+        // We trim this for letting hesperides ignore the whitespaces on properties in the templates
+        // Ex. {{ db.user.login  }} should be treated as {{db.user.login}}
+        // This has impact to valorsiation's name and mustach templates
+        this.name = name.trim();
         this.comment = comment;
     }
 

--- a/src/test/java/com/vsct/dt/hesperides/files/FilesTest.java
+++ b/src/test/java/com/vsct/dt/hesperides/files/FilesTest.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.mock;
 
 /**
  * Created by william_montaz on 03/09/14.
+ * Updated by Tidiane SIDIBE on 09/11/2016
  */
 public class FilesTest {
 
@@ -197,6 +198,12 @@ public class FilesTest {
             - a property named property.with.dots (wich is a specific requirement not handled at first by MustacheJava
             - a property named property.with.html.escapable (to make sure content is html escaped !)
 
+            Cases added for whitespaces ignoring
+            - a property named property.with.whitespaces.at.start
+            - a property named property.with.whitespaces.at.end
+            - a property named property.with.whitespaces.at.everywhere
+            - a property named property.with.whitespaces.and.default (witch makes use of @default on property with whitespaces)
+
            The property content will rely on an instance property to make sure thoose are injected
            Properties will use comment to be sure thoose are removed for generation
 
@@ -205,7 +212,10 @@ public class FilesTest {
         TemplateData templateData = TemplateData.withTemplateName("template_from_module")
                 .withFilename("filename")
                 .withLocation("location")
-                .withContent("{{no_comment}}, {{content|comment for content}}, {{property.with.dots|some comment here}}, {{property.with.html.escapable|and comment here}}")
+                .withContent(
+                        "{{no_comment}}, {{content|comment for content}}, {{property.with.dots|some comment here}}, {{property.with.html.escapable|and comment here}}" +
+                        "You know what ? {{         property.with.whitespaces.at.start|@comment \"Spaces at start\"}}, {{property.with.whitespaces.at.end   |@comment \"Spaces at end\"}}, {{  property named property.with.whitespaces.at.everywhere  | @comment \"Spaces everywhere\"}} and {{  property.with.whitespaces.and.default      | @comment \"Spaces at start and end with default value\" @default \"This is my default value!\"}}"
+                )
                 .withRights(null)
                 .build();
         Module module = new Module(moduleKey, Sets.newHashSet(), 1L);
@@ -217,7 +227,10 @@ public class FilesTest {
                 new KeyValueValorisation("no_comment", "OK"),
                 new KeyValueValorisation("content", "the instance name is {{name}}"),
                 new KeyValueValorisation("property.with.dots", "I am dotted"),
-                new KeyValueValorisation("property.with.html.escapable", "I use escapable chars \"'")
+                new KeyValueValorisation("property.with.html.escapable", "I use escapable chars \"'"),
+                new KeyValueValorisation("      property.with.whitespaces.at.start", "I have spaces at start"),
+                new KeyValueValorisation("property.with.whitespaces.at.end      ", "I have spaces at end"),
+                new KeyValueValorisation("  property named property.with.whitespaces.at.everywhere      ", "I have spaces everywhere")
         ), Sets.newHashSet());
 
         /*
@@ -273,7 +286,7 @@ public class FilesTest {
         /* ACTUAL CALL */
         String content = files.getFile("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model);
 
-        assertThat(content).isEqualTo("OK, the instance name is SUPER_INSTANCE, I am dotted, I use escapable chars \"'");
+        assertThat(content).isEqualTo("OK, the instance name is SUPER_INSTANCE, I am dotted, I use escapable chars \"'You know what ? I have spaces at start, I have spaces at end, I have spaces everywhere and This is my default value!");
 
     }
 


### PR DESCRIPTION
Not in tamples, {{ myprop }} is treated like {{myprop}}.