### PR TITLE
Issue/#1 - Delete spaces after/before key name in module/instance properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target/
 *.iml
 hesperides.yml
+hesperides.iml

--- a/src/main/java/com/vsct/dt/hesperides/applications/MustacheScope.java
+++ b/src/main/java/com/vsct/dt/hesperides/applications/MustacheScope.java
@@ -77,14 +77,13 @@ public class MustacheScope implements Map<String, Object> {
 
     public Set<KeyValuePropertyModel> getMissingKeyValueProperties() {
         return getMissingKeyValueProperties(scope);
-
-
     }
 
     private Set<KeyValuePropertyModel> getMissingKeyValueProperties(Map<String, Object> scope){
         /* Iterate through the scope. There can be string scope object or lists (depending if it comes from KeyValue or Iterable properties) */
         Set<KeyValuePropertyModel> missingKeyValueProperties = new HashSet<>();
         for (Map.Entry<String, Object> entry : scope.entrySet()) {
+
             Object scopeObject = entry.getValue();
             if (scopeObject instanceof String) {
                 String value = (String) scopeObject;
@@ -109,14 +108,22 @@ public class MustacheScope implements Map<String, Object> {
     public static class InjectableMustacheScope {
 
         private final Set<ValorisationData> valorisations;
+
         private InjectableMustacheScope(Set<ValorisationData> valorisations) {
             Preconditions.checkNotNull(valorisations);
             this.valorisations = valorisations;
         }
 
         public InjectableMustacheScope inject(Map<String, String> injectedValues) {
-            if(injectedValues == null || injectedValues.size() == 0) return this;
-            Set<ValorisationData> injectedValorisations = valorisations.stream().map(valorisation -> valorisation.inject(injectedValues)).collect(Collectors.toSet());
+
+            if(injectedValues == null || injectedValues.size() == 0){
+                return this;
+            }
+
+            Set<ValorisationData> injectedValorisations = valorisations.stream().map(valorisation -> {
+                return valorisation.inject(injectedValues);
+            }).collect(Collectors.toSet());
+
             return new InjectableMustacheScope(injectedValorisations);
         }
 

--- a/src/main/java/com/vsct/dt/hesperides/resources/KeyValueValorisation.java
+++ b/src/main/java/com/vsct/dt/hesperides/resources/KeyValueValorisation.java
@@ -82,8 +82,9 @@ public final class KeyValueValorisation extends Valorisation {
     private String injectMapOfKeyValueInTemplateString(String value, final Map<String, String> context) {
         return replaceWithPattern(value, valorisation_templating_pattern, captured -> {
 
-            // TODO : this should be trimed as in KeyValueValorisationData ?
-            String capture = captured.group(1);
+            // This is trimed to let hesperides reuse global properties event if they are
+            // used in valuations with some whitespaces
+            String capture = captured.group(1).trim();
 
             String replacement = context.get(capture);
             if (replacement == null) {

--- a/src/main/java/com/vsct/dt/hesperides/resources/KeyValueValorisation.java
+++ b/src/main/java/com/vsct/dt/hesperides/resources/KeyValueValorisation.java
@@ -71,8 +71,7 @@ public final class KeyValueValorisation extends Valorisation {
 
     public String getValue() {
         //This helps to deal with old values that have been set to null
-        if (value == null) return "";
-        else return value;
+        return (value == null) ? "" : value;
     }
 
     @Override
@@ -82,7 +81,10 @@ public final class KeyValueValorisation extends Valorisation {
 
     private String injectMapOfKeyValueInTemplateString(String value, final Map<String, String> context) {
         return replaceWithPattern(value, valorisation_templating_pattern, captured -> {
+
+            // TODO : this should be trimed as in KeyValueValorisationData ?
             String capture = captured.group(1);
+
             String replacement = context.get(capture);
             if (replacement == null) {
                 return captured.group();

--- a/src/main/java/com/vsct/dt/hesperides/templating/platform/KeyValueValorisationData.java
+++ b/src/main/java/com/vsct/dt/hesperides/templating/platform/KeyValueValorisationData.java
@@ -37,6 +37,9 @@ import java.util.regex.Pattern;
 
 /**
  * Created by william_montaz on 10/07/14.
+ *
+ * Modified by tidiane_sidibe on 10/11/2016 : Adding whitespaces ignoring when using global properties
+ *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSnakeCase
@@ -73,7 +76,12 @@ public final class KeyValueValorisationData extends ValorisationData {
 
     private String injectMapOfKeyValueInTemplateString(String value, final Map<String, String> context) {
         return replaceWithPattern(value, VALORISATION_TEMPLATING_PATTERN, captured -> {
-            String capture = captured.group(1);
+
+            // This is trimed to let hesperides reuse global properties event if they are
+            // used in valuations with some whitespaces
+            String capture = captured.group(1).trim();
+
+            // Find if there is a replacement if the context
             String replacement = context.get(capture);
             if (replacement == null) {
                 return captured.group();

--- a/src/main/java/com/vsct/dt/hesperides/templating/platform/KeyValueValorisationData.java
+++ b/src/main/java/com/vsct/dt/hesperides/templating/platform/KeyValueValorisationData.java
@@ -60,8 +60,7 @@ public final class KeyValueValorisationData extends ValorisationData {
 
     public String getValue() {
         //This helps to deal with old values that have been set to null
-        if (value == null) return "";
-        else return value;
+        return (value == null) ? "" : value;
     }
 
     @Override

--- a/src/main/java/com/vsct/dt/hesperides/templating/platform/PropertiesData.java
+++ b/src/main/java/com/vsct/dt/hesperides/templating/platform/PropertiesData.java
@@ -92,6 +92,7 @@ public final class PropertiesData {
         /* Prepare what will be injected in the values */
         Map<String, String> injectableKeyValueValorisations = keyValueProperties.stream().collect(Collectors.toMap(ValorisationData::getName, KeyValueValorisationData::getValue));
         Map<String, String> injectablePlatformValorisations = platformValorisations.stream().collect(Collectors.toMap(ValorisationData::getName, KeyValueValorisationData::getValue));
+
         /* Erase local valorisations by platform valorisations */
         injectableKeyValueValorisations.putAll(injectablePlatformValorisations);
 

--- a/src/main/java/com/vsct/dt/hesperides/templating/platform/ValorisationData.java
+++ b/src/main/java/com/vsct/dt/hesperides/templating/platform/ValorisationData.java
@@ -42,6 +42,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Created by william_montaz on 28/07/2015.
+ *
+ * Modified by tidiane_sidibe on 10/11/2016 : Adding whitespaces ignoring when using global properties
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonDeserialize(using = ValorisationData.JacksonDeserializer.class)
@@ -53,12 +55,12 @@ public class ValorisationData {
     @JsonCreator
     public ValorisationData(@JsonProperty("name") final String name) {
         checkNotNull(!Strings.isNullOrEmpty(name), "A valorisation name should not be empty or null");
-        this.name = name;
+        this.name = name.trim();
     }
 
     @JsonProperty("name")
     public String getName() {
-        return name;
+        return name.trim();
     }
 
     public MustacheScopeEntry<String, Object> toMustacheScopeEntry(){

--- a/src/main/java/com/vsct/dt/hesperides/templating/platform/ValorisationData.java
+++ b/src/main/java/com/vsct/dt/hesperides/templating/platform/ValorisationData.java
@@ -55,7 +55,10 @@ public class ValorisationData {
     @JsonCreator
     public ValorisationData(@JsonProperty("name") final String name) {
         checkNotNull(!Strings.isNullOrEmpty(name), "A valorisation name should not be empty or null");
-        this.name = name.trim();
+
+        // At this point, name should not be null, but it's seems to be tha case for some stored data !
+        // So we trim only if not null !
+        this.name = (name != null) ? name.trim() : name;
     }
 
     @JsonProperty("name")

--- a/src/test/java/com/vsct/dt/hesperides/applications/PropertiesTest.java
+++ b/src/test/java/com/vsct/dt/hesperides/applications/PropertiesTest.java
@@ -537,6 +537,37 @@ public class PropertiesTest {
     }
 
     @Test
+    public void get_instance_model_should_ignore_whitespaces_on_properties_names(){
+        // The valuations, simple
+        Set<KeyValueValorisationData> kvp = Sets.newHashSet();
+
+        kvp.add(new KeyValueValorisationData("name1", "value of name without space on instance property name {{instance}}"));
+        kvp.add(new KeyValueValorisationData("name2", "value of name with a space at the start of instance property name {{ instance}}"));
+        kvp.add(new KeyValueValorisationData("name3", "value of name with spaces at start and end of instance property name {{  instance   }}"));
+
+        //The valuations, iterable
+        IterableValorisationData.IterableValorisationItemData item1 = new IterableValorisationData.IterableValorisationItemData("blockOfProperties", Sets.newHashSet(new KeyValueValorisationData("field1", "value with spaces {{  instance }}")));
+        IterableValorisationData.IterableValorisationItemData item2 = new IterableValorisationData.IterableValorisationItemData("blockOfProperties2", Sets.newHashSet(new KeyValueValorisationData("field1", "value without spaces {{instance}}")));
+
+        IterableValorisationData iv1 = new IterableValorisationData("iterable1", Lists.newArrayList(item1, item2));
+
+        IterableValorisationData.IterableValorisationItemData item3 = new IterableValorisationData.IterableValorisationItemData("blockOfProperties", Sets.newHashSet(new KeyValueValorisationData("field1", "value with spaces {{ otherInstance}}"), new KeyValueValorisationData("field2", "value with spaces {{ otherInstance  }}")));
+        IterableValorisationData.IterableValorisationItemData item4 = new IterableValorisationData.IterableValorisationItemData("blockOfProperties2", Sets.newHashSet(new KeyValueValorisationData("field1", "value with spaces {{  otherInstance  }}"), new KeyValueValorisationData("field2", "value without spaces {{otherInstance}}")));
+
+        IterableValorisationData iv2 = new IterableValorisationData("iterable2", Lists.newArrayList(item3, item4));
+
+        // The properties
+        PropertiesData properties = new PropertiesData(kvp, Sets.newHashSet(iv1, iv2));
+
+        // Instance model
+        InstanceModel model = properties.generateInstanceModel(null);
+
+        assertThat(model.getKeys().size()).isEqualTo(2);
+        assertThat(model.getKeys().contains(new KeyValuePropertyModel("instance", ""))).isTrue();
+        assertThat(model.getKeys().contains(new KeyValuePropertyModel("otherInstance", ""))).isTrue();
+    }
+
+    @Test
     public void get_instance_model_should_return_model_with_keys_refering_to_themselves(){
         //Create the properties
         Set<KeyValueValorisationData> kvp = Sets.newHashSet();
@@ -554,8 +585,6 @@ public class PropertiesTest {
         assertThat(model.getKeys().size()).isEqualTo(2);
         assertThat(model.getKeys().contains(new KeyValuePropertyModel("name3", ""))).isTrue();
         assertThat(model.getKeys().contains(new KeyValuePropertyModel("key2", ""))).isTrue();
-
-
     }
 
     @Test
@@ -599,4 +628,42 @@ public class PropertiesTest {
         assertThat(model.getKeys().contains(new KeyValuePropertyModel("key8", ""))).isTrue();
     }
 
+    @Test
+    public void get_instance_model_should_not_produce_instance_properties_when_global_properties_already_exists_ignoring_whitespaces(){
+        // Valuations, simple
+        Set<KeyValueValorisationData> kvp = Sets.newHashSet();
+
+        kvp.add(new KeyValueValorisationData("name1", "value with space at start {{ global}}"));
+        kvp.add(new KeyValueValorisationData("name2", "value with space at end {{global }}"));
+        kvp.add(new KeyValueValorisationData("name3", "value with space everywhere {{ global }}"));
+        kvp.add(new KeyValueValorisationData("name4", "value with instance {{instance}}"));
+        kvp.add(new KeyValueValorisationData("name5", "value with instance with some spaces {{ instance }}")); // normally already tested
+
+        //The valuations, iterable
+        IterableValorisationData.IterableValorisationItemData item1 = new IterableValorisationData.IterableValorisationItemData("blockOfProperties", Sets.newHashSet(new KeyValueValorisationData("field1", "value with spaces {{  otherInstance }}")));
+        IterableValorisationData.IterableValorisationItemData item2 = new IterableValorisationData.IterableValorisationItemData("blockOfProperties2", Sets.newHashSet(new KeyValueValorisationData("field1", "value without spaces {{instance }}")));
+
+        IterableValorisationData iv1 = new IterableValorisationData("iterable1", Lists.newArrayList(item1, item2));
+
+        IterableValorisationData.IterableValorisationItemData item3 = new IterableValorisationData.IterableValorisationItemData("blockOfProperties", Sets.newHashSet(new KeyValueValorisationData("field1", "value with spaces {{ global}}"), new KeyValueValorisationData("field2", "value with spaces {{ global  }}")));
+        IterableValorisationData.IterableValorisationItemData item4 = new IterableValorisationData.IterableValorisationItemData("blockOfProperties2", Sets.newHashSet(new KeyValueValorisationData("field1", "value with spaces {{  global  }}"), new KeyValueValorisationData("field2", "value without spaces {{global}}")));
+
+        IterableValorisationData iv2 = new IterableValorisationData("iterable2", Lists.newArrayList(item3, item4));
+
+        // Properties
+        PropertiesData properties = new PropertiesData(kvp, Sets.newHashSet(iv1, iv2));
+
+        // Global properties
+        Set<KeyValueValorisationData> globals = Sets.newHashSet();
+        globals.add(new KeyValueValorisationData("  global      ", "global value")); //a little bit exaggerated, but can't trust users ;)
+
+        // Get instance model with globals
+        InstanceModel model = properties.generateInstanceModel(globals);
+
+        assertThat(model.getKeys().size()).isEqualTo(2);
+        assertThat(model.getKeys().contains(new KeyValuePropertyModel("instance", ""))).isTrue();
+        assertThat(model.getKeys().contains(new KeyValuePropertyModel("otherInstance", ""))).isTrue();
+        assertThat(model.getKeys().contains(new KeyValuePropertyModel("global", ""))).isFalse();
+
+    }
 }


### PR DESCRIPTION
## Fix description 

Hesperides now ignores the whitespace in these situations

1. Using a global property in module valuations with whitespaces
   Whitespaces are ignored and the global property is found and used.

2. Adding instance properties several times with some whitespaces
  Ex. value : ***{{ prop_instance}}/{{prop_instance}}***
  Hesperides only creates one instance property ignoring whitespaces

