### PR TITLE
[Issue#25] We can now simulate instance

### DIFF
--- a/src/main/java/com/vsct/dt/hesperides/files/Files.java
+++ b/src/main/java/com/vsct/dt/hesperides/files/Files.java
@@ -83,7 +83,7 @@ public class Files {
      * @param instanceName
      * @return
      */
-    public Set<HesperidesFile> getLocations(String applicationName, String platformName, String path, String moduleName, String moduleVersion, boolean isModuleWorkingCopy, String instanceName) {
+    public Set<HesperidesFile> getLocations(String applicationName, String platformName, String path, String moduleName, String moduleVersion, boolean isModuleWorkingCopy, String instanceName, Boolean simulate) {
 
         PlatformKey platformKey = PlatformKey.withName(platformName)
                 .withApplicationName(applicationName)
@@ -119,7 +119,7 @@ public class Files {
         }
 
         //Get the instance
-        InstanceData instance = applicationModule.getInstance(instanceName).orElseThrow(() -> new MissingResourceException("There is no instance " + instanceName + " in platform " + applicationName + "/" + platformName));
+        InstanceData instance = applicationModule.getInstance(instanceName, simulate).orElseThrow(() -> new MissingResourceException("There is no instance " + instanceName + " in platform " + applicationName + "/" + platformName));
 
         PropertiesData platformGlobalProperties = applications.getProperties(platformKey, "#");
 
@@ -230,7 +230,8 @@ public class Files {
                           boolean isModuleWorkingCopy,
                           String instanceName,
                           String templateNamespace,
-                          String templateName, HesperidesPropertiesModel model) {
+                          String templateName, HesperidesPropertiesModel model,
+                          Boolean simulate) {
 
         PlatformKey platformKey = PlatformKey.withName(platformName)
                 .withApplicationName(applicationName)
@@ -248,7 +249,7 @@ public class Files {
         ApplicationModuleData applicationModule = platform.findModule(moduleName, moduleVersion, isModuleWorkingCopy, path).orElseThrow(() -> new MissingResourceException("There is no module "+moduleName+"/"+moduleVersion+"/"+(isModuleWorkingCopy ? "WorkingCopy":"Release" + " defined for platform "+applicationName+"/"+platformName +" at path "+path)));
 
         //Get the instance
-        InstanceData instance = applicationModule.getInstance(instanceName).orElseThrow(() -> new MissingResourceException("There is no instance " + instanceName + " in platform " + applicationName + "/" + platformName));
+        InstanceData instance = applicationModule.getInstance(instanceName, simulate).orElseThrow(() -> new MissingResourceException("There is no instance " + instanceName + " in platform " + applicationName + "/" + platformName));
 
         Set<KeyValueValorisationData> hesperidesModulePredefinedScope = applicationModule.generateHesperidesPredefinedScope();
         hesperidesPlatformPredefinedScope.addAll(hesperidesModulePredefinedScope);

--- a/src/main/java/com/vsct/dt/hesperides/resources/HesperidesFilesResource.java
+++ b/src/main/java/com/vsct/dt/hesperides/resources/HesperidesFilesResource.java
@@ -68,7 +68,8 @@ public class HesperidesFilesResource extends BaseResource {
                                           @PathParam("module_name") final String moduleName,
                                           @PathParam("module_version") final String moduleVersion,
                                           @PathParam("instance_name") final String instanceName,
-                                          @QueryParam("isWorkingCopy") final Boolean isWorkingCopy) throws Exception {
+                                          @QueryParam("isWorkingCopy") final Boolean isWorkingCopy,
+                                          @QueryParam("simulate") final Boolean simulate) throws Exception {
 
         checkQueryParameterNotEmpty("application_name", applicationName);
         checkQueryParameterNotEmpty("platform_name", platformName);
@@ -78,7 +79,7 @@ public class HesperidesFilesResource extends BaseResource {
         checkQueryParameterNotEmpty("instance_name", instanceName);
         checkQueryParameterNotEmpty("isWorkingCopy", isWorkingCopy);
 
-        Set<HesperidesFile> locations = files.getLocations(applicationName, platformName, path, moduleName, moduleVersion, isWorkingCopy, instanceName);
+        Set<HesperidesFile> locations = files.getLocations(applicationName, platformName, path, moduleName, moduleVersion, isWorkingCopy, instanceName, simulate == null ? false : simulate);
         return locations.stream().map(file -> {
             String url = null;
             try {
@@ -168,7 +169,8 @@ public class HesperidesFilesResource extends BaseResource {
                           @PathParam("instance_name") final String instanceName,
                           @PathParam("filename") final String filename,
                           @QueryParam("isWorkingCopy") final Boolean isWorkingCopy,
-                          @QueryParam("template_namespace") final String templateNamespace) throws Exception {
+                          @QueryParam("template_namespace") final String templateNamespace,
+                          @QueryParam("simulate") final Boolean simulate) throws Exception {
 
         checkQueryParameterNotEmpty("application_name", applicationName);
         checkQueryParameterNotEmpty("platform_name", platformName);
@@ -182,7 +184,7 @@ public class HesperidesFilesResource extends BaseResource {
 
         HesperidesPropertiesModel model = !isWorkingCopy ? this.moduleResource.getReleaseModel(user, moduleName, moduleVersion) : this.moduleResource.getWorkingCopyModel(user, moduleName, moduleVersion);
 
-        return files.getFile(applicationName, platformName, path, moduleName, moduleVersion, isWorkingCopy, instanceName, templateNamespace, filename, model);
+        return files.getFile(applicationName, platformName, path, moduleName, moduleVersion, isWorkingCopy, instanceName, templateNamespace, filename, model, simulate == null ? false : simulate);
     }
 
     private String getContentLocation(final String applicationName,

--- a/src/main/java/com/vsct/dt/hesperides/templating/platform/ApplicationModuleData.java
+++ b/src/main/java/com/vsct/dt/hesperides/templating/platform/ApplicationModuleData.java
@@ -164,13 +164,21 @@ public class ApplicationModuleData {
         return predefinedScope;
     }
 
-    public Optional<InstanceData> getInstance(String instanceName){
+    public Optional<InstanceData> getInstance(String instanceName, Boolean simulate_empty){
         for(InstanceData instance : instances){
             if(instance.getName().equals(instanceName)){
                 return Optional.of(instance);
             }
         }
+        if (simulate_empty) {
+            return Optional.of(InstanceData.withInstanceName(instanceName).withKeyValue(new HashSet<>()).build());
+        }
         return Optional.empty();
+    }
+
+
+    public Optional<InstanceData> getInstance(String instanceName){
+        return getInstance(instanceName, false);
     }
 
     public static IVersion withApplicationName(final String name) {

--- a/src/test/java/com/vsct/dt/hesperides/files/FilesTest.java
+++ b/src/test/java/com/vsct/dt/hesperides/files/FilesTest.java
@@ -174,7 +174,7 @@ public class FilesTest {
                 PROPERTIES_CONVERTER.toPropertiesData(properties), 1L, comment);
 
         /* ACTUAL CALL */
-        Set<HesperidesFile> fileSet = files.getLocations("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name");
+        Set<HesperidesFile> fileSet = files.getLocations("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name", false);
 
         assertThat(fileSet.size()).isEqualTo(3);
 
@@ -284,7 +284,7 @@ public class FilesTest {
 
 
         /* ACTUAL CALL */
-        String content = files.getFile("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model);
+        String content = files.getFile("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model, false);
 
         assertThat(content).isEqualTo("OK, the instance name is SUPER_INSTANCE, I am dotted, I use escapable chars \"'You know what ? I have spaces at start, I have spaces at end, I have spaces everywhere and This is my default value!");
 
@@ -366,7 +366,7 @@ public class FilesTest {
                 PROPERTIES_CONVERTER.toPropertiesData(globalProperties), 2L, comment);
 
         /* ACTUAL CALL */
-        String content = files.getFile("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model);
+        String content = files.getFile("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model, false);
 
         assertThat(content).isEqualTo("global_property");
 
@@ -375,7 +375,7 @@ public class FilesTest {
                 PROPERTIES_CONVERTER.toPropertiesData(emptyGlobalProperties), 3L, comment);
 
         /* ACTUAL CALL */
-        String content2 = files.getFile("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model);
+        String content2 = files.getFile("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model, false);
 
         assertThat(content2).isEqualTo("local_property");
 
@@ -450,7 +450,7 @@ public class FilesTest {
 
 
         /* ACTUAL CALL */
-        String content = files.getFile("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model);
+        String content = files.getFile("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model, false);
 
         assertThat(content).isEqualTo("ferrari\n" +
                 "300000\n" +
@@ -517,12 +517,12 @@ public class FilesTest {
 
 
         /* ACTUAL CALL */
-        Set<HesperidesFile> filesSet = files.getLocations("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name");
+        Set<HesperidesFile> filesSet = files.getLocations("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name", false);
         HesperidesFile fileInfo = filesSet.iterator().next();
         assertThat(fileInfo.getFilename()).isEqualTo("the_app_name_file");
         assertThat(fileInfo.getLocation()).isEqualTo("the_app_name_the_pltfm_name_version");
 
-        String content = files.getFile("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model);
+        String content = files.getFile("the_app_name", "the_pltfm_name", "#path#1", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model, false);
 
         assertThat(content).isEqualTo("the_app_name the_pltfm_name version");
     }
@@ -581,12 +581,12 @@ public class FilesTest {
 
 
         /* ACTUAL CALL */
-        Set<HesperidesFile> filesSet = files.getLocations("the_app_name", "the_pltfm_name", "#COMPONENT#TECHNO", "the_module_name", "the_module_version", true, "the_instance_name");
+        Set<HesperidesFile> filesSet = files.getLocations("the_app_name", "the_pltfm_name", "#COMPONENT#TECHNO", "the_module_name", "the_module_version", true, "the_instance_name", false);
         HesperidesFile fileInfo = filesSet.iterator().next();
         assertThat(fileInfo.getFilename()).isEqualTo("the_module_name_file");
         assertThat(fileInfo.getLocation()).isEqualTo("the_module_name_the_module_version");
 
-        String content = files.getFile("the_app_name", "the_pltfm_name", "#COMPONENT#TECHNO", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model);
+        String content = files.getFile("the_app_name", "the_pltfm_name", "#COMPONENT#TECHNO", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model, false);
 
         assertThat(content).isEqualTo("the_module_name the_module_version COMPONENT TECHNO");
     }
@@ -645,12 +645,12 @@ public class FilesTest {
 
 
         /* ACTUAL CALL */
-        Set<HesperidesFile> filesSet = files.getLocations("the_app_name", "the_pltfm_name", "#COMPONENT#TECHNO", "the_module_name", "the_module_version", true, "the_instance_name");
+        Set<HesperidesFile> filesSet = files.getLocations("the_app_name", "the_pltfm_name", "#COMPONENT#TECHNO", "the_module_name", "the_module_version", true, "the_instance_name", false);
         HesperidesFile fileInfo = filesSet.iterator().next();
         assertThat(fileInfo.getFilename()).isEqualTo("the_instance_name_file");
         assertThat(fileInfo.getLocation()).isEqualTo("the_instance_name_location");
 
-        String content = files.getFile("the_app_name", "the_pltfm_name", "#COMPONENT#TECHNO", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model);
+        String content = files.getFile("the_app_name", "the_pltfm_name", "#COMPONENT#TECHNO", "the_module_name", "the_module_version", true, "the_instance_name", createdTemplate.getNamespace(), "template_from_module", model, false);
 
         assertThat(content).isEqualTo("the_instance_name");
     }

--- a/src/test/java/com/vsct/dt/hesperides/resources/HesperidesFilesResourceTest.java
+++ b/src/test/java/com/vsct/dt/hesperides/resources/HesperidesFilesResourceTest.java
@@ -128,7 +128,7 @@ public class HesperidesFilesResourceTest {
         HesperidesFile file1 = new HesperidesFile("the_template_namespace", "the_template_name", "/some/location", "some_filename1.sh", null);
         HesperidesFile file2 = new HesperidesFile("the_template_namespace", "the_template_name", "/some/location", "some_filename2.sh", null);
 
-        when(files.getLocations("my_app", "my_pltfm", "the_path", "my_module", "the_module_version", true, "my_instance")).thenReturn(Sets.newHashSet(file1, file2));
+        when(files.getLocations("my_app", "my_pltfm", "the_path", "my_module", "the_module_version", true, "my_instance", false)).thenReturn(Sets.newHashSet(file1, file2));
 
         FileListItem fileListItem1 = new FileListItem("/some/location/some_filename1.sh", "/rest/files/applications/my_app/platforms/my_pltfm/the_path/my_module/the_module_version/instances/my_instance/the_template_name?isWorkingCopy=true&template_namespace=the_template_namespace");
         FileListItem fileListItem2 = new FileListItem("/some/location/some_filename2.sh", "/rest/files/applications/my_app/platforms/my_pltfm/the_path/my_module/the_module_version/instances/my_instance/the_template_name?isWorkingCopy=true&template_namespace=the_template_namespace");
@@ -144,7 +144,7 @@ public class HesperidesFilesResourceTest {
         //Same as the one above, but use some special characters for url generation
         HesperidesFile file1 = new HesperidesFile("templates#techno#1.0#RELEASE", "name with spaces", "/some/location", "some_filename1.sh", null);
 
-        when(files.getLocations("my app", "my pltfm", "the path", "my#module", "the#module#version", true, "my instance")).thenReturn(Sets.newHashSet(file1));
+        when(files.getLocations("my app", "my pltfm", "the path", "my#module", "the#module#version", true, "my instance", false)).thenReturn(Sets.newHashSet(file1));
 
         FileListItem fileListItem1 = new FileListItem("/some/location/some_filename1.sh", "/rest/files/applications/my%20app/platforms/my%20pltfm/the%20path/my%23module/the%23module%23version/instances/my%20instance/name%20with%20spaces?isWorkingCopy=true&template_namespace=templates%23techno%231.0%23RELEASE");
 
@@ -179,7 +179,7 @@ public class HesperidesFilesResourceTest {
     @Test(expected = UniformInterfaceException.class)
     public void should_get_generated_file_for_application_platform_path_module_infos_instance_filename_with_isWorkingcopy_and_template_namespace_params() throws Exception {
 
-        when(files.getFile("some_app", "some_pltfm", "a_given_path", "module_name", "module_version", true, "the_instance_name", "the_template_namespace", "the_filename", model)).thenReturn("Ze file content");
+        when(files.getFile("some_app", "some_pltfm", "a_given_path", "module_name", "module_version", true, "the_instance_name", "the_template_namespace", "the_filename", model, false)).thenReturn("Ze file content");
 
         assertThat(withoutAuth("/files/applications/some_app/platforms/some_pltfm/a_given_path/module_name/module_version/instances/the_instance_name/the_filename")
                 .queryParam("isWorkingCopy", "true")
@@ -426,7 +426,7 @@ public class HesperidesFilesResourceTest {
                     module.isWorkingCopy(),
                     instance.getName(),
                     template.getNamespace(),
-                    template.getName(), model);
+                    template.getName(), model, false);
             fail("An error must be occure");
         } catch (MissingResourceException e) {
             assertThat(e.getMessage()).isEqualTo(String.format("Property 'prop1' in template '%s/%s' must be set.", template.getNamespace(), template.getName()));
@@ -507,7 +507,7 @@ public class HesperidesFilesResourceTest {
                     module.isWorkingCopy(),
                     instance.getName(),
                     template.getNamespace(),
-                    template.getName(), model);
+                    template.getName(), model, false);
 
         assertThat(content).isEqualTo("prop1=\nprop2=truc machin chose");
     }
@@ -590,7 +590,7 @@ public class HesperidesFilesResourceTest {
                 module.isWorkingCopy(),
                 instance.getName(),
                 template.getNamespace(),
-                template.getName(), model);
+                template.getName(), model, false);
 
         assertThat(content).isEqualTo("test_instance=[][this_is_working]");
     }

--- a/src/test/java/com/vsct/dt/hesperides/resources/HesperidesFilesResourceTest.java
+++ b/src/test/java/com/vsct/dt/hesperides/resources/HesperidesFilesResourceTest.java
@@ -356,7 +356,8 @@ public class HesperidesFilesResourceTest {
             assertThat(e.getResponse().getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
         }
     }
-    
+
+    @Test
     public void should_return_404_if_getting_file_with_required_property() throws NoSuchFieldException, IllegalAccessException {
         PlatformKey platformKey = PlatformKey.withName("CUR1")
                 .withApplicationName("RAC")
@@ -413,6 +414,7 @@ public class HesperidesFilesResourceTest {
                 ImmutableSet.of());
 
         when(modulesAggregate.getModel(moduleKey)).thenReturn(Optional.of(templateModel));
+        when(applicationsAggregate.getSecuredProperties(any(), any(), any())).thenReturn(platformGlobalProperties);
 
         Files hesperidesFiles = new Files(applicationsAggregate, modulesAggregate, templatePackages);
 
@@ -593,6 +595,156 @@ public class HesperidesFilesResourceTest {
                 template.getName(), model, false);
 
         assertThat(content).isEqualTo("test_instance=[][this_is_working]");
+    }
+
+    @Test
+    public void should_return_404_if_instance_name_wrong() throws NoSuchFieldException, IllegalAccessException {
+        PlatformKey platformKey = PlatformKey.withName("CUR1")
+                .withApplicationName("RAC")
+                .build();
+
+        // Appel 1
+        String propertiesPath = "#WAS#EuronetWS#1.0.0.0#WORKINGCOPY";
+
+        InstanceData instance = InstanceData.withInstanceName("TOTO")
+                .withKeyValue(ImmutableSet.of())
+                .build();
+
+        ApplicationModuleData module = ApplicationModuleData.withApplicationName("EuronetWS")
+                .withVersion("1.0.0.0")
+                .withPath(propertiesPath)
+                .withId(1)
+                .withInstances(ImmutableSet.of(instance))
+                .isWorkingcopy()
+                .build();
+
+        PlatformData platform = PlatformData.withPlatformName(platformKey.getName())
+                .withApplicationName(platformKey.getApplicationName())
+                .withApplicationVersion("1.0.0.0")
+                .withModules(ImmutableSet.of(module))
+                .withVersion(11L)
+                .build();
+
+        when(applicationsAggregate.getPlatform(platformKey)).thenReturn(Optional.of(platform));
+
+        // Appel 2 getProperties()
+        PropertiesData platformGlobalProperties = new PropertiesData(ImmutableSet.of(), ImmutableSet.of());
+
+        when(applicationsAggregate.getProperties(platformKey, "#WAS#EuronetWS#1.0.0.0#WORKINGCOPY#EuronetWS#1.0.0.0#WORKINGCOPY")).thenReturn(platformGlobalProperties);
+        when(applicationsAggregate.getProperties(platformKey, "#")).thenReturn(platformGlobalProperties);
+
+        when(applicationsAggregate.getSecuredProperties(platformKey, "#WAS#EuronetWS#1.0.0.0#WORKINGCOPY#EuronetWS#1.0.0.0#WORKINGCOPY", model)).thenReturn(platformGlobalProperties);
+        when(applicationsAggregate.getSecuredProperties(platformKey, "#", model)).thenReturn(platformGlobalProperties);
+
+        // Appel 3 modules.getTemplate()
+        String templateName = "TitiEtRominet";
+
+        Template template = new Template("modules#EuronetWS#1.0.0.0#WORKINGCOPY", templateName, "truc.txt",
+                "/tmp", "prop1={{prop1|@required}}\n" +
+                "prop2={{prop2|@default 'truc machin chose' @comment \"cool !\"}}", null, 2);
+
+        ModuleKey moduleKey = new ModuleKey(
+                "EuronetWS",
+                new HesperidesVersion("1.0.0.0", true));
+
+        when(modulesAggregate.getTemplate(moduleKey, templateName)).thenReturn(Optional.of(template));
+
+        // Appel 4 modules.getModel)
+        HesperidesPropertiesModel templateModel = new HesperidesPropertiesModel(ImmutableSet.of(), ImmutableSet.of());
+
+        when(modulesAggregate.getModel(moduleKey)).thenReturn(Optional.of(templateModel));
+
+        Files hesperidesFiles = new Files(applicationsAggregate, modulesAggregate, templatePackages);
+
+
+        try {
+            hesperidesFiles.getFile(
+                    platformKey.getApplicationName(),
+                    platformKey.getName(),
+                    propertiesPath,
+                    moduleKey.getName(),
+                    module.getVersion(),
+                    module.isWorkingCopy(),
+                    "AYA",
+                    template.getNamespace(),
+                    template.getName(), model, false);
+            fail("An error must be occure");
+        } catch (MissingResourceException e) {
+            assertThat(e.getMessage()).isEqualTo(String.format("There is no instance AYA in platform %s/%s", platformKey.getApplicationName(), platformKey.getName()));
+        }
+    }
+
+    @Test
+    public void should_not_return_404_if_instance_name_wrong_and_simulate_true() throws NoSuchFieldException, IllegalAccessException {
+        PlatformKey platformKey = PlatformKey.withName("CUR1")
+                .withApplicationName("RAC")
+                .build();
+
+        // Appel 1
+        String propertiesPath = "#WAS#EuronetWS#1.0.0.0#WORKINGCOPY";
+
+        InstanceData instance = InstanceData.withInstanceName("TOTO")
+                .withKeyValue(ImmutableSet.of())
+                .build();
+
+        ApplicationModuleData module = ApplicationModuleData.withApplicationName("EuronetWS")
+                .withVersion("1.0.0.0")
+                .withPath(propertiesPath)
+                .withId(1)
+                .withInstances(ImmutableSet.of(instance))
+                .isWorkingcopy()
+                .build();
+
+        PlatformData platform = PlatformData.withPlatformName(platformKey.getName())
+                .withApplicationName(platformKey.getApplicationName())
+                .withApplicationVersion("1.0.0.0")
+                .withModules(ImmutableSet.of(module))
+                .withVersion(11L)
+                .build();
+
+        when(applicationsAggregate.getPlatform(platformKey)).thenReturn(Optional.of(platform));
+
+        // Appel 2 getProperties()
+        PropertiesData platformGlobalProperties = new PropertiesData(ImmutableSet.of(), ImmutableSet.of());
+
+        when(applicationsAggregate.getProperties(platformKey, "#WAS#EuronetWS#1.0.0.0#WORKINGCOPY#EuronetWS#1.0.0.0#WORKINGCOPY")).thenReturn(platformGlobalProperties);
+        when(applicationsAggregate.getProperties(platformKey, "#")).thenReturn(platformGlobalProperties);
+
+        when(applicationsAggregate.getSecuredProperties(platformKey, "#WAS#EuronetWS#1.0.0.0#WORKINGCOPY#EuronetWS#1.0.0.0#WORKINGCOPY", model)).thenReturn(platformGlobalProperties);
+        when(applicationsAggregate.getSecuredProperties(platformKey, "#", model)).thenReturn(platformGlobalProperties);
+
+        // Appel 3 modules.getTemplate()
+        String templateName = "TitiEtRominet";
+
+        Template template = new Template("modules#EuronetWS#1.0.0.0#WORKINGCOPY", templateName, "truc.txt",
+                "/tmp", "{{hesperides.instance.name}}", null, 2);
+
+        ModuleKey moduleKey = new ModuleKey(
+                "EuronetWS",
+                new HesperidesVersion("1.0.0.0", true));
+
+        when(modulesAggregate.getTemplate(moduleKey, templateName)).thenReturn(Optional.of(template));
+
+        // Appel 4 modules.getModel)
+        HesperidesPropertiesModel templateModel = new HesperidesPropertiesModel(ImmutableSet.of(), ImmutableSet.of());
+
+        when(modulesAggregate.getModel(moduleKey)).thenReturn(Optional.of(templateModel));
+
+        Files hesperidesFiles = new Files(applicationsAggregate, modulesAggregate, templatePackages);
+
+        String simulateInstanceName = "test_hesperides_instance_name_in_fake_instance";
+
+        String content = hesperidesFiles.getFile(
+                platformKey.getApplicationName(),
+                platformKey.getName(),
+                propertiesPath,
+                moduleKey.getName(),
+                module.getVersion(),
+                module.isWorkingCopy(),
+                simulateInstanceName,
+                template.getNamespace(),
+                template.getName(), model, true);
+        assertThat(content).isEqualTo(simulateInstanceName);
     }
 
     private static final ValueCode createProperty(final String value) throws NoSuchFieldException, IllegalAccessException {


### PR DESCRIPTION
To prevent creating pointless instances on hesperides, we can just call the file api with a desired instance name, if the simulate query param is set to true, hesperides will simulate the instance with the name you wanted.