### PR TITLE
[issue#47] Escape entities in html message

### DIFF
--- a/src/main/java/com/vsct/dt/hesperides/feedback/FeedbacksAggregate.java
+++ b/src/main/java/com/vsct/dt/hesperides/feedback/FeedbacksAggregate.java
@@ -29,6 +29,7 @@ import com.vsct.dt.hesperides.feedback.jsonObject.FeedbackJson;
 import com.vsct.dt.hesperides.proxy.ProxyConfiguration;
 import com.vsct.dt.hesperides.security.model.User;
 import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -183,7 +184,7 @@ public class FeedbacksAggregate extends FeedbackManagerAggregate implements Feed
 
         while (itWordList.hasNext()) {
             hipchatMessage.append("<p>")
-                .append(itWordList.next())
+                .append(StringEscapeUtils.escapeHtml(itWordList.next().toString()))
                 .append(("</p>"));
         }
 

--- a/src/test/java/com/vsct/dt/hesperides/feedback/FeedbacksTest.java
+++ b/src/test/java/com/vsct/dt/hesperides/feedback/FeedbacksTest.java
@@ -88,7 +88,7 @@ public class FeedbacksTest {
         // Mock call of feedbackJson
         when(feedbackJson.getFeedback()).thenReturn(feedbackObject);
         when(feedbackObject.getUrl()).thenReturn("https://hostname/url");
-        when(feedbackObject.getNote()).thenReturn("A message\non 2 lines");
+        when(feedbackObject.getNote()).thenReturn("A message\non 2 lines\nwith éà€");
 
         // Mock call of User
         when(user.getUsername()).thenReturn("username");
@@ -98,7 +98,7 @@ public class FeedbacksTest {
         assertThat(hipchatMessageBody).isNotEmpty();
         assertThat(hipchatMessageBody).isEqualTo("{\"from\": \"username\",\"color\": \"green\",\"message\": \"" +
                 "<p>When access to <a href='https://hostname/url'>https://hostname/url</a></p><p>A message</p>" +
-                "<p>on 2 lines</p>" +
+                "<p>on 2 lines</p><p>with &eacute;&agrave;&euro;</p>" +
                 "<a href='https://hostname/hipchatPathStorageTest/imageName.png'>Download screenshot</a>" +
                 "\",\"notify\": \"true\",\"message_format\": \"html\"}");
     }


### PR DESCRIPTION
Allow é, à, € and others entities in feedback message