### PR TITLE
[issue/#67] remove sun packages

### DIFF
--- a/src/main/java/com/vsct/dt/hesperides/feedback/FeedbacksAggregate.java
+++ b/src/main/java/com/vsct/dt/hesperides/feedback/FeedbacksAggregate.java
@@ -41,7 +41,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.misc.BASE64Decoder;
 
 import javax.imageio.ImageIO;
 import javax.net.ssl.SSLContext;
@@ -50,10 +49,7 @@ import java.io.*;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Created by stephane_fret on 07/03/2017.
@@ -217,8 +213,7 @@ public class FeedbacksAggregate extends FeedbackManagerAggregate implements Feed
         byte[] imageByte;
 
         try {
-            BASE64Decoder decoder = new BASE64Decoder();
-            imageByte = decoder.decodeBuffer(imageString);
+            imageByte = Base64.getDecoder().decode(imageString);
             ByteArrayInputStream bis = new ByteArrayInputStream(imageByte);
             bufferedImage = ImageIO.read(bis);
             bis.close();

--- a/src/main/java/com/vsct/dt/hesperides/templating/platform/PropertiesData.java
+++ b/src/main/java/com/vsct/dt/hesperides/templating/platform/PropertiesData.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import com.vsct.dt.hesperides.applications.*;
 import com.vsct.dt.hesperides.applications.MustacheScope.InjectableMustacheScope;
 import com.vsct.dt.hesperides.templating.models.KeyValuePropertyModel;

--- a/src/main/java/com/vsct/dt/hesperides/templating/platform/ValorisationData.java
+++ b/src/main/java/com/vsct/dt/hesperides/templating/platform/ValorisationData.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Strings;
 import com.vsct.dt.hesperides.applications.MustacheScopeEntry;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 
 import java.io.IOException;
 import java.util.Map;
@@ -67,7 +67,7 @@ public class ValorisationData {
     }
 
     public MustacheScopeEntry<String, Object> toMustacheScopeEntry(){
-        throw new NotImplementedException();
+        throw new NotImplementedException("");
     };
 
     @Override
@@ -88,7 +88,7 @@ public class ValorisationData {
     }
 
     public ValorisationData inject(Map<String, String> keyValueProperties){
-        throw new NotImplementedException();
+        throw new NotImplementedException("");
     };
 
     /* Use a specific deserializer to handle polymorphism and avoid changing the existing API */


### PR DESCRIPTION
- sun.misc.BASE64Decoder has been changed to java.util.Base64

- com.sun.org.apache.xpath.internal.operations.Bool has been removed as it wasn't used

- sun.reflect.generics.reflectiveObjects.NotImplementedException has been changed to sun.reflect.generics.reflectiveObjects.NotImplementedException (without message)