### PR TITLE
add hesperides-spring as module and remove the others as they are not…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,7 @@
     </distributionManagement>
 
     <modules>
-        <module>hesperides-core</module>
-        <module>hesperides-legacy</module>
-        <module>hesperides-bdd</module>
+        <module>hesperides-spring</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
… part of the spring boot poc

Ajout du module hesperides-spring dans le pom parent afin de lancer les tests automatiquement via travis-ci et que IntelliJ indexe le module.

Suppression de tous les autres modules du pom parent (hesperides-core, hesperides-legacy, hesperides-bdd) afin que les tests ne soient plus lancés



En plus de supprimer les modules du pom il faudrait les supprimer complètement du projet. Ils sont inutiles. Il faut repartir sur du code propre sans bruit