### PR TITLE
specify build and test stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,20 @@
 language: java
-
-jdk:
-  - oraclejdk8
+jdk: oraclejdk8
+sudo: false
 
 cache:
   directories:
     - "$HOME/.m2"
+before_cache:
+  - rm -rf $HOME/.m2/repository
+
+stages:
+  - build
+  - test
+
+jobs:
+  include:
+    - stage: build
+      script: ./mvnw clean package -Dmaven.test.skip=true
+    - stage: test
+      script: ./mvnw test


### PR DESCRIPTION
Utilisation des stages dans Travis permettant de mieux afficher les étapes et permettant de faire du parallélisme dans un stage et du séquentiel entre stages.

Ajout de deux stages :
- un qui package
- l'autre qui test

![capturetravis](https://user-images.githubusercontent.com/3106586/36476215-80260c22-16fd-11e8-9a97-b01f4b977d30.PNG)
