### PR TITLE
add integration tests within docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ jobs:
       script: ./mvnw clean package -Dmaven.test.skip=true
     - stage: test
       script: ./mvnw test
+    - stage: test
+      env:
+        - INTEGRATION TEST
+      script: ./mvnw -pl tests/integration verify -P integration-test
     - stage: docker
       if: type != pull_request AND fork = false
       script: ./.travis/docker_build_push.sh

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <module>infrastructure</module>
         <module>bootstrap</module>
         <module>tests/bdd</module>
+        <module>tests/integration</module>
         <module>tests/tech</module>
     </modules>
 
@@ -54,6 +55,9 @@
         <spring-security-test.version>4.2.4.RELEASE</spring-security-test.version>
         <swagger.version>1.5.18</swagger.version>
         <!-- Plugins -->
+        <docker-maven-plugin.version>0.24.0</docker-maven-plugin.version>
+        <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.hesperides</groupId>
+        <artifactId>hesperides-spring</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test-integration</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hesperides</groupId>
+            <artifactId>bootstrap</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Spring -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <!-- The Configuration of the development profile -->
+        <profile>
+            <id>dev</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <build.profile.id>dev</build.profile.id>
+                <skip.integration.tests>true</skip.integration.tests>
+                <skip.unit.tests>false</skip.unit.tests>
+            </properties>
+        </profile>
+        <!-- The Configuration of the integration-test profile -->
+        <profile>
+            <id>integration-test</id>
+            <properties>
+                <build.profile.id>integration-test</build.profile.id>
+                <skip.integration.tests>false</skip.integration.tests>
+                <skip.unit.tests>true</skip.unit.tests>
+            </properties>
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>${docker-maven-plugin.version}</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <name>redis:3.0.3</name>
+                            <alias>redis</alias>
+                            <run>
+                                <ports>
+                                    <port>6379:6379</port>
+                                </ports>
+                            </run>
+                        </image>
+                        <image>
+                            <name>elasticsearch:1.7.5</name>
+                            <alias>search</alias>
+                            <run>
+                                <ports>
+                                    <port>9200:9200</port>
+                                    <port>9300:9300</port>
+                                </ports>
+                                <wait>
+                                    <http>
+                                        <method>GET</method>
+                                        <status>200</status>
+                                        <url>http://localhost:9200/_cat/health</url>
+                                    </http>
+                                    <time>60000</time>
+                                </wait>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-failsafe-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/IT*.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tests/integration/src/test/java/org/hesperides/tests/integration/ITSample.java
+++ b/tests/integration/src/test/java/org/hesperides/tests/integration/ITSample.java
@@ -1,0 +1,36 @@
+package org.hesperides.tests.integration;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ITSample {
+
+    @Test
+    public void checkElasticsearchConnection() throws IOException {
+        URL url = new URL("http://localhost:9200/_cluster/health");
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("GET");
+        int responseCode = con.getResponseCode();
+        assertEquals(200, responseCode);
+    }
+
+    @Test
+    public void checkRedisConnection() {
+        JedisPool pool = new JedisPool();
+        Jedis jedis = pool.getResource();
+        assertTrue(!jedis.ping().isEmpty());
+        jedis.close();
+    }
+
+}


### PR DESCRIPTION
Ajout d'un module maven tests/integration permettant de lancer des tests non mockés
-> Lance deux conteneurs docker (elasticsearch + redis )
-> Lance les tests
-> Coupe les conteneurs

Mise en place de deux tests simples de connexions à elasticsearch et redis

Commande maven `./mvnw -pl tests/integration clean verify -P integration-test`

Maj de `.travis.yml` pour effectuer les tests d'intégration en parallèle de ceux classiques