### PR TITLE
add CrossOrigin annotation using default values

### DIFF
--- a/presentation/src/main/java/org/hesperides/presentation/controllers/ModuleController.java
+++ b/presentation/src/main/java/org/hesperides/presentation/controllers/ModuleController.java
@@ -44,6 +44,7 @@ import static org.springframework.http.HttpStatus.SEE_OTHER;
 @Api("/modules")
 @RestController
 @RequestMapping("/modules")
+@CrossOrigin
 public class ModuleController extends BaseController {
 
     private final ModuleUseCases moduleUseCases;

--- a/presentation/src/main/java/org/hesperides/presentation/controllers/TemplateController.java
+++ b/presentation/src/main/java/org/hesperides/presentation/controllers/TemplateController.java
@@ -21,6 +21,7 @@ import static org.springframework.web.util.UriComponentsBuilder.fromPath;
 @Api("/modules")
 @RestController
 @RequestMapping("/modules/{module_name}/{module_version}")
+@CrossOrigin
 public class TemplateController extends BaseController {
 
     private final ModuleUseCases moduleUseCases;


### PR DESCRIPTION
Issue #172 

Ajout de l'annotation @CrossOrigin sur les controllers utilisant ses valeurs par défaut (tout origine, tout header)

> This @CrossOrigin annotation enables cross-origin requests only for this specific method. By default, its allows all origins, all headers, the HTTP methods specified in the @RequestMapping annotation and a maxAge of 30 minutes is used. 

Guide --> https://spring.io/guides/gs/rest-service-cors/
