### PR TITLE
Feature/gitflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ rebel.xml
 .rebel.xml.bak
 data/
 
-/hesperides-spring/bootstrap/src/main/resources/application-corp.yml
+/hesperides/bootstrap/src/main/resources/application-corp.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM openjdk:8-jre-alpine
 
-COPY bootstrap/target/hesperides-*.jar hesperides-spring.jar
+COPY bootstrap/target/hesperides-*.jar hesperides.jar
 
 ENTRYPOINT ["/usr/bin/java"]
 
-CMD ["-jar","/hesperides-spring.jar"]
+CMD ["-jar","/hesperides.jar"]
 
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Build the whole project:
 
 Build Docker image
 
-    docker build . -t hesperides/hesperides-spring
+    docker build . -t hesperides/hesperides
 
 ## Run
 
@@ -80,15 +80,15 @@ Run backend via Docker
 
 Run backend manually
 
-    java -jar bootstrap/target/hesperides-spring.jar
+    java -jar bootstrap/target/hesperides.jar
     
 Run backend using Docker
 
-    docker run -d [-e ENV_VAR=ENV_VALUE] -p 8080:8080 --network hesperides_hesperides-network hesperides/hesperides-spring
+    docker run -d [-e ENV_VAR=ENV_VALUE] -p 8080:8080 --network hesperides_hesperides-network hesperides/hesperides
     
 Run without ldap or elasticsearch
 
-    java -jar bootstrap/target/hesperides-spring.jar -Dspring.profiles.active=noldap,fake_mongo
+    java -jar bootstrap/target/hesperides.jar -Dspring.profiles.active=noldap,fake_mongo
 
 ## Documentation
 

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>org.hesperides</groupId>
-        <artifactId>hesperides-spring</artifactId>
+        <artifactId>hesperides</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>org.hesperides</groupId>
-        <artifactId>hesperides-spring</artifactId>
+        <artifactId>hesperides</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>org.hesperides</groupId>
-        <artifactId>hesperides-spring</artifactId>
+        <artifactId>hesperides</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>org.hesperides</groupId>
-        <artifactId>hesperides-spring</artifactId>
+        <artifactId>hesperides</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.hesperides</groupId>
-    <artifactId>hesperides-spring</artifactId>
+    <artifactId>hesperides</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
-    <name>hesperides-spring</name>
+    <name>hesperides</name>
     <description>Hesperides, templated files generator</description>
     <url>https://github.com/voyages-sncf-technologies/hesperides</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <swagger2.version>2.8.0</swagger2.version>
         <!-- Plugins -->
         <docker-maven-plugin.version>0.24.0</docker-maven-plugin.version>
+        <gitflow-maven-plugin.version>1.9.0</gitflow-maven-plugin.version>
         <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
@@ -326,6 +327,23 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.amashchenko.maven.plugin</groupId>
+                <artifactId>gitflow-maven-plugin</artifactId>
+                <version>${gitflow-maven-plugin.version}</version>
+                <configuration>
+                    <gitFlowConfig>
+                        <productionBranch>master</productionBranch>
+                        <developmentBranch>develop</developmentBranch>
+                        <featureBranchPrefix>feature/</featureBranchPrefix>
+                        <releaseBranchPrefix>release/</releaseBranchPrefix>
+                        <hotfixBranchPrefix>hotfix/</hotfixBranchPrefix>
+                        <supportBranchPrefix>support/</supportBranchPrefix>
+                        <versionTagPrefix>hesperides-</versionTagPrefix>
+                        <origin>origin</origin>
+                    </gitFlowConfig>
+                </configuration>
             </plugin>
         </plugins>
         <pluginManagement>

--- a/presentation/pom.xml
+++ b/presentation/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>hesperides-spring</artifactId>
+        <artifactId>hesperides</artifactId>
         <groupId>org.hesperides</groupId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>

--- a/tests/bdd/pom.xml
+++ b/tests/bdd/pom.xml
@@ -5,7 +5,7 @@
 
     <parent>
         <groupId>org.hesperides</groupId>
-        <artifactId>hesperides-spring</artifactId>
+        <artifactId>hesperides</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>org.hesperides</groupId>
-        <artifactId>hesperides-spring</artifactId>
+        <artifactId>hesperides</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>

--- a/tests/tech/pom.xml
+++ b/tests/tech/pom.xml
@@ -5,7 +5,7 @@
 
     <parent>
         <groupId>org.hesperides</groupId>
-        <artifactId>hesperides-spring</artifactId>
+        <artifactId>hesperides</artifactId>
         <version>0.0.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>


### PR DESCRIPTION
Permet de lancer les commandes git flow via maven et évite d'initier le projet avec `git flow init`

Configuration git flow paramétrée pour Hespérides 👍 
```
                        <productionBranch>master</productionBranch>
                        <developmentBranch>develop</developmentBranch>
                        <featureBranchPrefix>feature/</featureBranchPrefix>
                        <releaseBranchPrefix>release/</releaseBranchPrefix>
                        <hotfixBranchPrefix>hotfix/</hotfixBranchPrefix>
                        <supportBranchPrefix>support/</supportBranchPrefix>
                        <versionTagPrefix>hesperides-</versionTagPrefix>
                        <origin>origin</origin>
```

GitHub du plugin: https://github.com/aleksandr-m/gitflow-maven-plugin
