### PR TITLE
Feature/javadoc sources

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.hesperides</groupId>
         <artifactId>hesperides</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>application</artifactId>

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.hesperides</groupId>
         <artifactId>hesperides</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>bootstrap</artifactId>

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.hesperides</groupId>
         <artifactId>hesperides</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>domain</artifactId>

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.hesperides</groupId>
         <artifactId>hesperides</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>infrastructure</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,9 @@
         <gitflow-maven-plugin.version>1.9.0</gitflow-maven-plugin.version>
         <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+        <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     </properties>
@@ -324,6 +326,33 @@
                         <phase>verify</phase>
                         <goals>
                             <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.hesperides</groupId>
     <artifactId>hesperides</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2-SNAPSHOT</version>
 
     <name>hesperides</name>
     <description>Hesperides, templated files generator</description>

--- a/presentation/pom.xml
+++ b/presentation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>hesperides</artifactId>
         <groupId>org.hesperides</groupId>
-        <version>0.0.1</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tests/bdd/pom.xml
+++ b/tests/bdd/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.hesperides</groupId>
         <artifactId>hesperides</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.hesperides</groupId>
         <artifactId>hesperides</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/tests/tech/pom.xml
+++ b/tests/tech/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.hesperides</groupId>
         <artifactId>hesperides</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
* Passage de Hesperides en 0.0.2-SNAPSHOT (au lieu de 0.0.1)

Afin de pouvoir publier une version releasée, sonatype veut de la javadoc et des sources #197 donc :
* Ajout du plugin javadoc
* Ajout du plugin source