### PR TITLE
Ajout scope test sur spring-boot-starter-test

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -23,6 +23,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/presentation/pom.xml
+++ b/presentation/pom.xml
@@ -58,6 +58,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
Deux scopes "test" étaient manquant dans deux modules :
```
<groupId>org.springframework.boot</groupId>
<artifactId>spring-boot-starter-test</artifactId>
```

Lors de la création d'une nouvelle application ayant pour dépendance une partie celles d'Hespérides, les tests d'Hespérides se lançaient aussi :astonished: