### PR TITLE
deploy release on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ stages:
 - name: build
 - name: test
 - name: deploy
-  if: branch = develop AND type != pull_request AND fork = false
+  if: (branch = develop OR tag = true) AND type != pull_request AND fork = false
 - name: docker
 jobs:
   include:


### PR DESCRIPTION
Le stage de deploiement vers sonatype se réalise que sur la branche `develop`, sur laquelle nous sommes uniquement en snapshot. Donc on déploie jamais de release.

Je viens de modifier la condition pour ajouter les tags, là nous sommes en release. A voir ensuite si ça déploie correctement