### PR TITLE
Fix Mongo Configuration : use distinct names for beans

### DIFF
--- a/bootstrap/src/main/resources/application-mongo.yml
+++ b/bootstrap/src/main/resources/application-mongo.yml
@@ -3,5 +3,3 @@ event_store:
   uri: ${EVENT_STORE_MONGO_URI:mongodb://localhost:27017/event_store}
 projection_repository:
   uri: ${PROJECTION_REPOSITORY_MONGO_URI:mongodb://localhost:27017/projection_repository}
-
-

--- a/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/MongoProjectionRepositoryConfiguration.java
+++ b/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/MongoProjectionRepositoryConfiguration.java
@@ -31,17 +31,17 @@ public class MongoProjectionRepositoryConfiguration {
     private String uri;
 
     @Bean
-    public MongoTemplate mongoTemplate(MongoClientURI uri) {
-        return new MongoTemplate(mongo(uri), uri.getDatabase());
+    public MongoTemplate mongoTemplate(MongoClientURI projectionMongoClientUri) {
+        return new MongoTemplate(mongo(projectionMongoClientUri), projectionMongoClientUri.getDatabase());
     }
 
     @Bean
-    public Mongo mongo(MongoClientURI uri) {
-        return new MongoClient(uri);
+    public Mongo mongo(MongoClientURI projectionMongoClientUri) {
+        return new MongoClient(projectionMongoClientUri);
     }
 
     @Bean
-    public MongoClientURI uri() {
+    public MongoClientURI projectionMongoClientUri() {
         return new MongoClientURI(uri);
     }
 }

--- a/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/eventstores/AxonMongoEventStoreConfiguration.java
+++ b/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/eventstores/AxonMongoEventStoreConfiguration.java
@@ -29,18 +29,18 @@ public class AxonMongoEventStoreConfiguration {
     private String uri;
 
     @Bean
-    public MongoClient mongo(MongoClientURI uri) {
-        return new MongoClient(uri);
+    public MongoClient axonMongoClient(MongoClientURI axonMongoClientUri) {
+        return new MongoClient(axonMongoClientUri);
     }
 
     @Bean
-    public MongoClientURI uri() {
+    public MongoClientURI axonMongoClientUri() {
         return new MongoClientURI(uri);
     }
 
     @Bean
     @Primary
-    public EventStorageEngine eventStore(MongoClientURI uri) {
-        return new MongoEventStorageEngine(new DefaultMongoTemplate(mongo(uri), uri.getDatabase()));
+    public EventStorageEngine eventStore(MongoClientURI axonMongoClientUri) {
+        return new MongoEventStorageEngine(new DefaultMongoTemplate(axonMongoClient(axonMongoClientUri), axonMongoClientUri.getDatabase()));
     }
 }


### PR DESCRIPTION
Pendant que madame prépare à manger 🤣 

Spring mélangeait les conf mongo entre les events et les projections car le bean `MongoClientURI` portait le même nom entre les deux.

Solution : donner un nom distinct entre les deux conf.

Fix #289 