### PR TITLE
discover tags using branch name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ env:
 stages:
 - name: build
 - name: test
-- name: deploy
-  if: (branch = develop OR tags = true) AND type != pull_request AND fork = false
 - name: docker
+- name: deploy
+  if: (branch = develop OR branch =~ ^v[0-9]) AND type != pull_request AND fork = false
 jobs:
   include:
   - stage: build
@@ -36,6 +36,9 @@ jobs:
   - stage: test
     env: INTEGRATION TEST
     script: "./mvnw -pl tests/integration verify -P integration-test"
+  - stage: docker
+    if: type != pull_request AND fork = false
+    script: "./.travis/docker_build_push.sh"
   - stage: deploy
     env: DEPLOY TO NEXUS (SONATYPE)
     before_script:
@@ -43,8 +46,5 @@ jobs:
       -in ./.travis/codesigning.asc.enc -out ./.travis/codesigning.asc -d
     - gpg --import ./.travis/codesigning.asc
     script: "./mvnw deploy -DskipTests=true -Ddeploy --settings ./.travis/deploy-settings.xml"
-  - stage: docker
-    if: type != pull_request AND fork = false
-    script: "./.travis/docker_build_push.sh"
 notifications:
   webhooks: https://outlook.office.com/webhook/b95afcd0-96b7-4034-9bcd-785973709f0a@85eca096-674d-4fd9-9a9e-ae1178e2ee56/TravisCI/e609ea50bd7d485fbc01b47299a0d35b/671e3320-57d1-49bb-a67a-950d08b12517


### PR DESCRIPTION
Dans `.travis.yml` la condition `tags = true` ne semble pas fonctionner.
-> Remplacé par `branch =~ ^v[0-9]` étant donné que tous les tags commencent par v et un chiffre.

J'ai placé le build de l'image docker avant le déploiement vers le nexus de sonatype, car le premier est plus prioritaire, le second n'est pas obligatoire et peut planter