### PR TITLE
Correction iso des retours du model et des templates de technos

### DIFF
--- a/core/application/src/main/java/org/hesperides/core/application/technos/TechnoUseCases.java
+++ b/core/application/src/main/java/org/hesperides/core/application/technos/TechnoUseCases.java
@@ -85,10 +85,11 @@ public class TechnoUseCases {
     }
 
     public List<TemplateView> getTemplates(TemplateContainer.Key technoKey) {
-        if (!queries.technoExists(technoKey)) {
-            throw new TechnoNotFoundException(technoKey);
+        List<TemplateView> templates = Collections.emptyList();
+        if (queries.technoExists(technoKey)) {
+            templates = queries.getTemplates(technoKey);
         }
-        return queries.getTemplates(technoKey);
+        return templates;
     }
 
     public TechnoView releaseTechno(TemplateContainer.Key existingTechnoKey, User user) {
@@ -135,9 +136,10 @@ public class TechnoUseCases {
     }
 
     public List<AbstractPropertyView> getProperties(TemplateContainer.Key technoKey) {
-        if (!queries.technoExists(technoKey)) {
-            throw new TechnoNotFoundException(technoKey);
+        List<AbstractPropertyView> properties = Collections.emptyList();
+        if (queries.technoExists(technoKey)) {
+            properties = queries.getProperties(technoKey);
         }
-        return queries.getProperties(technoKey);
+        return properties;
     }
 }

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/TechnosController.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/TechnosController.java
@@ -231,9 +231,6 @@ public class TechnosController extends AbstractController {
         TemplateContainer.Key technoKey = new Techno.Key(technoName, technoVersion, versionType);
         List<AbstractPropertyView> abstractPropertyViews = technoUseCases.getProperties(technoKey);
         ModelOutput modelOutput = new ModelOutput(abstractPropertyViews);
-
-        //TODO Gérer l'ordre des propriétés ?
-
         return ResponseEntity.ok(modelOutput);
     }
 }

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/io/templatecontainers/PartialTemplateIO.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/io/templatecontainers/PartialTemplateIO.java
@@ -5,11 +5,9 @@ import lombok.Value;
 import org.hesperides.core.domain.templatecontainers.queries.TemplateView;
 import org.hesperides.core.presentation.io.OnlyPrintableCharacters;
 
-import javax.validation.constraints.NotNull;
-
 @Value
 @AllArgsConstructor
-public class PartialTemplateIO implements Comparable<PartialTemplateIO> {
+public class PartialTemplateIO {
 
     @OnlyPrintableCharacters(subject = "name")
     String name;
@@ -24,17 +22,5 @@ public class PartialTemplateIO implements Comparable<PartialTemplateIO> {
         this.namespace = templateView.getNamespace();
         this.filename = templateView.getFilename();
         this.location = templateView.getLocation();
-    }
-
-    /**
-     * L'implémentation de l'interface Comparable nous permet de trier les partials templates par leur nom.
-     * Ce tri est nécessaire pour les tests de non régression.
-     *
-     * @param o
-     * @return
-     */
-    @Override
-    public int compareTo(@NotNull PartialTemplateIO o) {
-        return this.name.compareTo(o.name);
     }
 }

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/io/templatecontainers/PropertyOutput.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/io/templatecontainers/PropertyOutput.java
@@ -7,7 +7,6 @@ import lombok.Value;
 import org.hesperides.core.domain.templatecontainers.queries.AbstractPropertyView;
 import org.hesperides.core.domain.templatecontainers.queries.IterablePropertyView;
 import org.hesperides.core.domain.templatecontainers.queries.PropertyView;
-import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Type;
 import java.util.List;
@@ -18,7 +17,7 @@ import java.util.stream.Collectors;
 
 @Value
 @AllArgsConstructor
-public class PropertyOutput implements Comparable<PropertyOutput> {
+public class PropertyOutput {
 
     String name;
     @SerializedName("required")
@@ -89,12 +88,6 @@ public class PropertyOutput implements Comparable<PropertyOutput> {
                 .stream()
                 .map(PropertyOutput::new)
                 .collect(Collectors.toSet());
-    }
-
-    @Override
-    public int compareTo(@NotNull PropertyOutput o) {
-        //TODO Supprimer
-        return this.name.compareTo(o.name);
     }
 
     @Override

--- a/tests/bdd/src/test/java/org/hesperides/tests/bdd/technos/scenarios/DeleteTechnos.java
+++ b/tests/bdd/src/test/java/org/hesperides/tests/bdd/technos/scenarios/DeleteTechnos.java
@@ -1,6 +1,7 @@
 package org.hesperides.tests.bdd.technos.scenarios;
 
 import cucumber.api.java8.En;
+import org.hesperides.core.presentation.io.templatecontainers.PartialTemplateIO;
 import org.hesperides.tests.bdd.commons.HesperidesScenario;
 import org.hesperides.tests.bdd.modules.ModuleBuilder;
 import org.hesperides.tests.bdd.technos.TechnoBuilder;
@@ -9,7 +10,7 @@ import org.hesperides.tests.bdd.templatecontainers.builders.ModelBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 
-import static org.hesperides.tests.bdd.commons.HesperidesScenario.*;
+import static org.junit.Assert.assertEquals;
 
 public class DeleteTechnos extends HesperidesScenario implements En {
 
@@ -41,10 +42,9 @@ public class DeleteTechnos extends HesperidesScenario implements En {
         });
 
         Then("^this techno templates are also deleted$", () -> {
-            //s'assurer que la techno à été bien supprimé dans le 1er step => Given
             assertOK();
-            testContext.responseEntity = technoClient.getTemplates(technoBuilder.build(), String.class);
-            assertNotFound();
+            testContext.responseEntity = technoClient.getTemplates(technoBuilder.build(), PartialTemplateIO[].class);
+            assertEquals(0, getBodyAsArray().length);
             testContext.responseEntity = technoClient.getTemplate(technoBuilder.build().getName(), technoBuilder.build(), String.class);
             assertNotFound();
         });

--- a/tests/bdd/src/test/java/org/hesperides/tests/bdd/technos/scenarios/GetTechnosModel.java
+++ b/tests/bdd/src/test/java/org/hesperides/tests/bdd/technos/scenarios/GetTechnosModel.java
@@ -9,9 +9,9 @@ import org.hesperides.tests.bdd.templatecontainers.builders.ModelBuilder;
 import org.hesperides.tests.bdd.templatecontainers.builders.PropertyBuilder;
 import org.hesperides.tests.bdd.templatecontainers.builders.TemplateBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 
-import static org.hesperides.tests.bdd.commons.HesperidesScenario.*;
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
 
 public class GetTechnosModel extends HesperidesScenario implements En {
@@ -99,8 +99,9 @@ public class GetTechnosModel extends HesperidesScenario implements En {
             assertEquals(expectedModel, actualModel);
         });
 
-        Then("^the techno model if not found$", () -> {
-            assertNotFound();
+        Then("^the techno model is empty$", () -> {
+            ModelOutput expectedModel = new ModelOutput(Collections.emptySet(), Collections.emptySet());
+            assertEquals(expectedModel, testContext.getResponseBody());
         });
 
         Then("^the model of this techno doesn't contain the properties$", () -> {

--- a/tests/bdd/src/test/java/org/hesperides/tests/bdd/technos/scenarios/templates/GetTechnoTemplates.java
+++ b/tests/bdd/src/test/java/org/hesperides/tests/bdd/technos/scenarios/templates/GetTechnoTemplates.java
@@ -28,14 +28,12 @@ import org.hesperides.tests.bdd.technos.TechnoBuilder;
 import org.hesperides.tests.bdd.technos.TechnoClient;
 import org.hesperides.tests.bdd.templatecontainers.builders.TemplateBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.hesperides.tests.bdd.commons.HesperidesScenario.*;
 import static org.junit.Assert.assertEquals;
 
 public class GetTechnoTemplates extends HesperidesScenario implements En {
@@ -100,6 +98,10 @@ public class GetTechnoTemplates extends HesperidesScenario implements En {
 
         Then("^the templates techno is not found$", () -> {
             assertNotFound();
+        });
+
+        Then("^the list of techno templates is empty$", () -> {
+            assertEquals(0, getBodyAsArray().length);
         });
     }
 }

--- a/tests/bdd/src/test/resources/technos/get-technos-model.feature
+++ b/tests/bdd/src/test/resources/technos/get-technos-model.feature
@@ -20,8 +20,8 @@ Feature: Get techno model
 
   Scenario: get the model of a techno that doesn't exist
     Given a techno that doesn't exist
-    When I try to get the model of this techno
-    Then the techno model if not found
+    When I get the model of this techno
+    Then the techno model is empty
 
   Scenario: get the model of a techno with a deleted template
     Given an existing techno with properties

--- a/tests/bdd/src/test/resources/technos/templates/get-techno-templates.feature
+++ b/tests/bdd/src/test/resources/technos/templates/get-techno-templates.feature
@@ -30,8 +30,8 @@ Feature: Get techno templates
 
   Scenario: get the list of templates of a techno that doesn't exist
     Given a techno that doesn't exist
-    When I try to get the list of templates of this techno
-    Then the resource is not found
+    When I get the list of templates of this techno
+    Then the list of techno templates is empty
 
   Scenario: get a template of a techno that doesn't exist
     Given a techno that doesn't exist

--- a/tests/bdd/src/test/resources/technos/templates/get-techno-templates.feature
+++ b/tests/bdd/src/test/resources/technos/templates/get-techno-templates.feature
@@ -31,7 +31,7 @@ Feature: Get techno templates
   Scenario: get the list of templates of a techno that doesn't exist
     Given a techno that doesn't exist
     When I get the list of templates of this techno
-    Then the list of techno templates is empty
+    Then an empty list is returned
 
   Scenario: get a template of a techno that doesn't exist
     Given a techno that doesn't exist


### PR DESCRIPTION
Lorsqu'on tente de récupérer le model ou les templates d'une techno qui n'existe pas, le legacy ne renvoie pas une 404 mais un résultat vide.