### PR TITLE
Adding MongoClientHealthIndicator

### DIFF
--- a/bootstrap/src/main/resources/application.yml
+++ b/bootstrap/src/main/resources/application.yml
@@ -5,6 +5,12 @@ application:
   encoding: @project.build.sourceEncoding@
   java.version: @java.version@
 
+# /info actuator endpoint:
+info:
+  app:
+    name: @project.parent.artifactId@
+    version: @project.version@
+
 spring:
   application.name: HESPERIDES
   boot.admin.client.enabled: false
@@ -36,6 +42,9 @@ management:
   health:
     ldap:
       enabled: false
+  endpoint:
+    health:
+      show-details: always
   endpoints:
     web:
       base-path: /manage

--- a/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/MongoClientHealthIndicator.java
+++ b/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/MongoClientHealthIndicator.java
@@ -1,0 +1,60 @@
+package org.hesperides.core.infrastructure.mongo;
+
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hesperides.core.infrastructure.mongo.MongoProjectionRepositoryConfiguration.MONGO_CLIENT_BEAN_NAME;
+
+@Component
+public class MongoClientHealthIndicator implements HealthIndicator {
+
+    @Autowired
+    @Qualifier(MONGO_CLIENT_BEAN_NAME)
+    MongoClient mongoClient;
+
+    @Override
+    public Health health() {
+        MongoClientOptions mongoClientOptions = mongoClient.getMongoClientOptions();
+        Map<String, Object> details = new HashMap<String ,Object>() {{
+            put("applicationName", mongoClientOptions.getApplicationName());
+            put("description", mongoClientOptions.getDescription());
+            put("retryWrites", mongoClientOptions.getRetryWrites());
+            put("connectionsPerHost", mongoClientOptions.getConnectionsPerHost());
+            put("minConnectionsPerHost", mongoClientOptions.getMinConnectionsPerHost());
+            put("threadsAllowedToBlockForConnectionMultiplier", mongoClientOptions.getThreadsAllowedToBlockForConnectionMultiplier());
+            put("serverSelectionTimeout", mongoClientOptions.getServerSelectionTimeout());
+            put("maxWaitTime", mongoClientOptions.getMaxWaitTime());
+            put("maxConnectionIdleTime", mongoClientOptions.getMaxConnectionIdleTime());
+            put("connectTimeout", mongoClientOptions.getConnectTimeout());
+            put("socketTimeout", mongoClientOptions.getSocketTimeout());
+            put("heartbeatFrequency", mongoClientOptions.getHeartbeatFrequency());
+            put("minHeartbeatFrequency", mongoClientOptions.getMinHeartbeatFrequency());
+            put("heartbeatConnectTimeout", mongoClientOptions.getHeartbeatConnectTimeout());
+            put("heartbeatSocketTimeout", mongoClientOptions.getHeartbeatSocketTimeout());
+            put("localThreshold", mongoClientOptions.getLocalThreshold());
+            put("requiredReplicaSetName", mongoClientOptions.getRequiredReplicaSetName());
+            put("isSslEnabled", mongoClientOptions.isSslEnabled());
+            put("isSslInvalidHostNameAllowed", mongoClientOptions.isSslInvalidHostNameAllowed());
+            put("isAlwaysUseMBeans", mongoClientOptions.isAlwaysUseMBeans());
+            put("isCursorFinalizerEnabled", mongoClientOptions.isCursorFinalizerEnabled());
+            // Sadly spring-boot-actuator does not support nested details: https://github.com/spring-projects/spring-boot/issues/15795
+            put("readPreferences.isSlaveOk", mongoClientOptions.getReadPreference().isSlaveOk());
+            put("readPreferences.name", mongoClientOptions.getReadPreference().getName());
+            put("readConcern.level", mongoClientOptions.getReadConcern().getLevel());
+            put("readConcern.isServerDefault", mongoClientOptions.getReadConcern().isServerDefault());
+            put("writeConcern.w", mongoClientOptions.getWriteConcern().getWObject());
+            put("writeConcern.wTimeoutMS", mongoClientOptions.getWriteConcern().getWtimeout());
+            put("writeConcern.fsync", mongoClientOptions.getWriteConcern().getFsync());
+            put("writeConcern.journal", mongoClientOptions.getWriteConcern().getJournal());
+        }};
+        return Health.up().withDetails(details).build();
+    }
+}

--- a/documentation/architecture/mongodb.md
+++ b/documentation/architecture/mongodb.md
@@ -1,0 +1,24 @@
+# MongoDB
+
+_cf._ [lightweight-architecture-decision-records/database](../lightweight-architecture-decision-records/database.md) pour les détails du choix de base de donnée.
+
+## Configuration du client
+
+La configuration du client Mongo se fait via les variables d'environnement `EVENT_STORE_MONGO_URI` && `PROJECTION_REPOSITORY_MONGO_URI`
+qui contiennent la liste des noeuds du cluster à utiliser et les options de connexion à employer.
+
+## Consultation des options de connexion
+
+Un _HealthIndicator_ Spring Boot expose ces informations dans un endpoint HTTP:
+
+    curl -s http://localhost:8080/rest/manage/health
+
+## Write concern
+
+_cf._ <https://docs.mongodb.com/manual/reference/write-concern/> & <https://dzone.com/articles/mongodb-write-concern-3-must-know-caveats>
+
+Dans le cas d'Hesperides, nous recommendons l'utilisation d'un cluster de 6 noeuds Mongo redondé sur 2 datacenters.
+
+Dans ce cas, nous recommendons l'emploi de ces paramètres de connexion pour assurer que 
+
+    ?w=majority


### PR DESCRIPTION
```
$ curl -s http://localhost:8080/rest/manage/health/mongoClient | jq .details
{
  "readPreferences.isSlaveOk": false,
  "minHeartbeatFrequency": 500,
  "readConcern.level": null,
  "description": null,
  "connectionsPerHost": 100,
  "localThreshold": 15,
  "heartbeatSocketTimeout": 20000,
  "minConnectionsPerHost": 0,
  "isAlwaysUseMBeans": false,
  "connectTimeout": 10000,
  "socketTimeout": 0,
  "writeConcern.w": null,
  "applicationName": null,
  "retryWrites": false,
  "maxWaitTime": 120000,
  "readPreferences.name": "primary",
  "writeConcern.fsync": false,
  "threadsAllowedToBlockForConnectionMultiplier": 5,
  "writeConcern.wTimeoutMS": 0,
  "readConcern.isServerDefault": true,
  "isSslEnabled": false,
  "heartbeatFrequency": 10000,
  "writeConcern.journal": null,
  "serverSelectionTimeout": 30000,
  "isCursorFinalizerEnabled": true,
  "maxConnectionIdleTime": 0,
  "heartbeatConnectTimeout": 20000,
  "requiredReplicaSetName": null,
  "isSslInvalidHostNameAllowed": false
}
```