### PR TITLE
Sorting output of modules/perform_search by version - fix #595

### DIFF
--- a/core/domain/src/main/java/org/hesperides/core/domain/versions/SemVerComparator.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/versions/SemVerComparator.java
@@ -1,0 +1,55 @@
+package org.hesperides.core.domain.versions;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.StringTokenizer;
+import java.util.function.Function;
+
+import static java.lang.Integer.parseInt;
+
+/*
+ * Fourni un comparateur de Strings qui tente de les comparer
+ * avec du semantic versioning, mais fallback en comparaison lexicographique
+ */
+public class SemVerComparator {
+    // Inspiré de java.util.Comparator.comparing
+    public static <T> Comparator<T> semVerComparing(Function<? super T, String> keyExtractor) {
+        Objects.requireNonNull(keyExtractor);
+        return (Comparator<T> & Serializable)
+                (e1, e2) ->
+                    semVerCompare(keyExtractor.apply(e1), keyExtractor.apply(e2));
+    }
+
+    public static int semVerCompare(String v1, String v2) {
+        StringTokenizer semVer1 = new StringTokenizer(v1, ".");
+        StringTokenizer semVer2 = new StringTokenizer(v2, ".");
+        while (semVer1.hasMoreTokens() && semVer2.hasMoreTokens()) {
+            String partialVersion1 = semVer1.nextToken();
+            String partialVersion2 = semVer2.nextToken();
+            try {
+                int partialIntVersion1 = parseInt(partialVersion1);
+                int partialIntVersion2 = parseInt(partialVersion2);
+                if (partialIntVersion1 != partialIntVersion2) {
+                    return partialIntVersion1 - partialIntVersion2;
+                }
+            } catch (NumberFormatException numberFormatException) {
+                // Fallback: comparaison de String
+                if (!partialVersion1.equals(partialVersion2)) {
+                    return partialVersion1.compareTo(partialVersion2);
+                }
+            }
+        }
+        if (semVer1.hasMoreTokens() && !semVer2.hasMoreTokens()) {
+            // La chaîne de versions v1 est plus longue => c'est elle la plus grande
+            return 1;
+        }
+        if (semVer2.hasMoreTokens() && !semVer1.hasMoreTokens()) {
+            // La chaîne de versions v2 est plus longue => c'est elle la plus grande
+            return -1;
+        }
+        // semVer1.hasMoreTokens() && semVer2.hasMoreTokens()
+        // On a parcouru toute la liste de chaque côté : les versions sont égales
+        return 0;
+    }
+}

--- a/core/domain/src/test/java/org/hesperides/core/domain/versions/SemVerComparatorTest.java
+++ b/core/domain/src/test/java/org/hesperides/core/domain/versions/SemVerComparatorTest.java
@@ -1,0 +1,62 @@
+/*
+ *
+ * This file is part of the Hesperides distribution.
+ * (https://github.com/voyages-sncf-technologies/hesperides)
+ * Copyright (c) 2016 VSCT.
+ *
+ * Hesperides is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, version 3.
+ *
+ * Hesperides is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
+package org.hesperides.core.domain.versions;
+
+import org.junit.Test;
+
+import static org.hesperides.core.domain.versions.SemVerComparator.semVerCompare;
+import static org.junit.Assert.assertEquals;
+
+public class SemVerComparatorTest {
+
+    @Test
+    public void test_semVerCompare_equal() {
+        assertEquals(semVerCompare("", ""), 0);
+        assertEquals(semVerCompare("0", "0"), 0);
+        assertEquals(semVerCompare("0.0", "0.0"), 0);
+        assertEquals(semVerCompare("0.a", "0.a"), 0);
+    }
+
+    @Test
+    public void test_semVerCompare_singleDigit() {
+        assertEquals(semVerCompare("2", "1"), 1);
+    }
+
+    @Test
+    public void test_semVerCompare_doubleDigits() {
+        assertEquals(semVerCompare("1.12", "1.2"), 10);
+    }
+
+    @Test
+    public void test_semVerCompare_tmp() {
+        assertEquals(semVerCompare("1.12", "1.2"), 10);
+    }
+
+    @Test
+    public void test_semVerCompare_nonNumeric() {
+        assertEquals(semVerCompare("b", "a"), 1);
+    }
+
+    @Test
+    public void test_semVerCompare_shorterChain() {
+        assertEquals(semVerCompare("1.2", "1"), 1);
+    }
+}

--- a/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/modules/MongoModuleRepository.java
+++ b/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/modules/MongoModuleRepository.java
@@ -49,7 +49,7 @@ public interface MongoModuleRepository extends MongoRepository<ModuleDocument, S
 
     List<ModuleDocument> findAllByTechnosId(String technoId);
 
-    @Query(value = "{ 'key.name': { '$regex' : ?0, '$options' : 'i' }, 'key.version': { '$regex' : ?1, '$options' : 'i' } }")
+    @Query(value = "{ 'key.name': { '$regex' : ?0, '$options' : 'i' }, 'key.version': { '$regex' : ?1, '$options' : 'i' } }", sort = "{ 'key.version' : -1 }")
     List<ModuleDocument> findAllByKeyNameLikeAndKeyVersionLike(String name, String version, Pageable pageable);
 
 }

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/ModulesController.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/ModulesController.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.hesperides.core.domain.security.User.fromAuthentication;
+import static org.hesperides.core.domain.versions.SemVerComparator.semVerComparing;
 
 @Slf4j
 @Api("/modules")
@@ -214,6 +215,7 @@ public class ModulesController extends AbstractController {
                 .orElse(Collections.emptyList())
                 .stream()
                 .map(ModuleIO::new)
+                .sorted(semVerComparing(ModuleIO::getVersion).reversed())
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(moduleOutputs);

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/modules/scenarios/SearchModules.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/modules/scenarios/SearchModules.java
@@ -8,7 +8,10 @@ import org.hesperides.test.bdd.modules.ModuleBuilder;
 import org.hesperides.test.bdd.modules.ModuleClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hesperides.test.bdd.versions.MatcherUtils.semVerGreaterThan;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class SearchModules extends HesperidesScenario implements En {
 
@@ -59,6 +62,14 @@ public class SearchModules extends HesperidesScenario implements En {
         Then("^the list of module results is limited to (\\d+) items$", (Integer limit) -> {
             assertOK();
             assertEquals(limit.intValue(), getBodyAsArray().length);
+        });
+
+        Then("^the resulting list is ordered using semantic versioning starting by the highest ones$", () -> {
+            assertOK();
+            ModuleIO[] modulesFound = getBodyAsArray();
+            for (int i = 0; i < modulesFound.length - 1; i++) {
+                assertThat(modulesFound[i].getVersion(), semVerGreaterThan(modulesFound[i + 1].getVersion()));
+            }
         });
 
         Then("^the search request is rejected with a bad request error$", () -> {

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/versions/MatcherUtils.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/versions/MatcherUtils.java
@@ -1,0 +1,22 @@
+package org.hesperides.test.bdd.versions;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+import static org.hesperides.core.domain.versions.SemVerComparator.semVerCompare;
+
+public class MatcherUtils {
+
+    public static TypeSafeMatcher<String> semVerGreaterThan(String v2) {
+        return new TypeSafeMatcher<String>() {
+            @Override
+            protected boolean matchesSafely(String v1) {
+                return semVerCompare(v1, v2) > 0;
+            }
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("greater than ").appendValue(v2);
+            }
+        };
+    }
+}

--- a/tests/bdd/src/test/resources/modules/search-modules.feature
+++ b/tests/bdd/src/test/resources/modules/search-modules.feature
@@ -17,6 +17,7 @@ Feature: Search modules
     Given a list of modules
     When I search for some of those modules
     Then the list of module results is limited to 10 items
+    And the resulting list is ordered using semantic versioning starting by the highest ones
 
   Scenario: search for a module that does not exist
     Given a list of modules


### PR DESCRIPTION
C'est seulement un début d'implémentation gérant le SemVer, mais il reste du travail, _cf._ https://github.com/voyages-sncf-technologies/hesperides/issues/595