### PR TITLE
Correction de la création de plateforme avec isProduction=null

### DIFF
--- a/core/presentation/src/main/java/org/hesperides/core/presentation/io/platforms/PlatformIO.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/io/platforms/PlatformIO.java
@@ -52,7 +52,6 @@ public class PlatformIO {
     @SerializedName("application_version")
     @JsonProperty("application_version")
     String version;
-    @NotNull
     @SerializedName("production")
     @JsonProperty("production")
     Boolean isProductionPlatform;


### PR DESCRIPTION
Test en cours de création, pour gagner du temps on peut déployer ce correctif.