### PR TITLE
Fix: /applications/using_module renvoie seulement les plateformes employant le module avec exactement la version indiquée - close #685

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ git fetch --tags upstream && gitchangelog && git add CHANGELOG.md
 ```
 
 <!-- gitchangelog START -->
+## _(unreleased)_
+### Fixed
+
+- /applications/using_module renvoie seulement les plateformes employant le module avec exactement la version indiquée - close #685. [Lucas Cimon]
+
+
+
 ## 2019-07-02
 ### Added
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,7 @@ HEALTHCHECK --interval=5s --timeout=3s --retries=3 CMD curl --fail http://localh
 
 # -XX:+ExitOnOutOfMemoryError // an OutOfMemoryError will often leave the JVM in an inconsistent state. Terminating the JVM will allow it to be restarted by an external process manager
 # -XX:+HeapDumpOnOutOfMemoryError // get a heap dump when the app crashes
-CMD ["/usr/bin/java", \
-     "-XX:+ExitOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError", \
-     "-Xms2g", "-Xmx4g", \
-     "-jar", "/hesperides.jar" \
-]
+CMD /usr/bin/java $JAVA_OPTS \
+     -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError \
+     -Xms2g -Xmx4g \
+     -jar /hesperides.jar

--- a/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/platforms/MongoPlatformProjectionRepository.java
+++ b/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/platforms/MongoPlatformProjectionRepository.java
@@ -303,7 +303,7 @@ public class MongoPlatformProjectionRepository implements PlatformProjectionRepo
     public List<ModulePlatformView> onGetPlatformUsingModuleQuery(GetPlatformsUsingModuleQuery query) {
         TemplateContainer.Key moduleKey = query.getModuleKey();
         List<PlatformDocument> platformDocuments = platformRepository
-                .findAllByDeployedModulesNameAndDeployedModulesVersionAndDeployedModulesIsWorkingCopy(
+                .findPlatformsUsingModule(
                         moduleKey.getName(), moduleKey.getVersion(), moduleKey.isWorkingCopy());
         return Optional.ofNullable(platformDocuments)
                 .map(List::stream)

--- a/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/platforms/MongoPlatformRepository.java
+++ b/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/platforms/MongoPlatformRepository.java
@@ -28,8 +28,8 @@ public interface MongoPlatformRepository extends MongoRepository<PlatformDocumen
 
     List<PlatformDocument> findAllByKeyApplicationName(String applicationName);
 
-    List<PlatformDocument> findAllByDeployedModulesNameAndDeployedModulesVersionAndDeployedModulesIsWorkingCopy(
-            String moduleName, String moduleVersion, boolean isWorkingCopy);
+    @Query(value = "{ 'deployedModules': { $elemMatch: { 'name' : ?0, 'version' : ?1, 'isWorkingCopy' : ?2 }}}", fields = "{ 'key' : 1 }")
+    List<PlatformDocument> findPlatformsUsingModule(String moduleName, String moduleVersion, boolean isWorkingCopy);
 
     @Query(value = "{}", fields = "{ 'key.applicationName' : 1 }")
     List<PlatformDocument> listApplicationNames();

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/CreatePlatforms.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/CreatePlatforms.java
@@ -44,7 +44,6 @@ import java.util.*;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
@@ -66,6 +65,7 @@ public class CreatePlatforms extends HesperidesScenario implements En {
     @Given("^an existing( prod)? platform" +
             "(?: named \"([^\"]*)\")?" +
             "( with this module)?" +
+            "( with two modules : one with the same name and one with the same version)?" +
             "(?: in logical group \"([^\"]*)\")?" +
             "( (?:and|with) an instance)?" +
             "( (?:and|with) valued properties)?" +
@@ -79,6 +79,7 @@ public class CreatePlatforms extends HesperidesScenario implements En {
     public void givenAnExistingPlatform(String isProd,
                                         String platformName,
                                         String withThisModule,
+                                        String withTwoModulesOneWithTheSameNameAndOneWithTheSameVersion,
                                         String logicalGroup,
                                         String withAnInstance,
                                         String withValuedProperties,
@@ -89,6 +90,7 @@ public class CreatePlatforms extends HesperidesScenario implements En {
                                         String withGlobalPropertiesAsInstanceValues,
                                         String withInstanceValueNamed,
                                         String withFilenameLocationValues) {
+        platformBuilder.reset();
         moduleBuilder.setLogicalGroup(logicalGroup);
 
         if (isNotEmpty(isProd)) {
@@ -112,6 +114,21 @@ public class CreatePlatforms extends HesperidesScenario implements En {
             }
             platformBuilder.withModule(moduleBuilder.build(), moduleBuilder.getPropertiesPath(), moduleBuilder.getLogicalGroup());
             platformBuilder.incrementDeployedModuleIds();
+        }
+        if (isNotEmpty(withTwoModulesOneWithTheSameNameAndOneWithTheSameVersion)) {
+            String origName = moduleBuilder.getName();
+            String origVersion = moduleBuilder.getVersion();
+            moduleBuilder.withName(origName + "2");
+            moduleBuilder.withVersion(origVersion);
+            platformBuilder.withModule(moduleBuilder.build(), moduleBuilder.getPropertiesPath(), moduleBuilder.getLogicalGroup());
+            platformBuilder.incrementDeployedModuleIds();
+            moduleBuilder.withName(origName);
+            moduleBuilder.withVersion(origVersion + "-SNAPSHOT");
+            platformBuilder.withModule(moduleBuilder.build(), moduleBuilder.getPropertiesPath(), moduleBuilder.getLogicalGroup());
+            platformBuilder.incrementDeployedModuleIds();
+            // On restaure les noms & versions :
+            moduleBuilder.withName(origName);
+            moduleBuilder.withVersion(origVersion);
         }
         commonSteps.ensureUserAuthIsSet();
         testContext.responseEntity = platformClient.create(platformBuilder.buildInput());

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/GetPlatformsUsingModule.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/GetPlatformsUsingModule.java
@@ -26,11 +26,14 @@ import org.hesperides.test.bdd.commons.HesperidesScenario;
 import org.hesperides.test.bdd.modules.ModuleBuilder;
 import org.hesperides.test.bdd.platforms.PlatformClient;
 import org.hesperides.test.bdd.platforms.PlatformHistory;
-import org.junit.Assert;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Arrays;
 import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class GetPlatformsUsingModule extends HesperidesScenario implements En {
 
@@ -51,7 +54,13 @@ public class GetPlatformsUsingModule extends HesperidesScenario implements En {
             assertOK();
             List<ModulePlatformsOutput> expectedPlatforms = platformHistory.buildModulePlatforms();
             List<ModulePlatformsOutput> actualPlatforms = Arrays.asList(getBodyAsArray());
-            Assert.assertEquals(expectedPlatforms, actualPlatforms);
+            assertEquals(expectedPlatforms, actualPlatforms);
+        });
+
+        Then("^a single platform is retrieved", () -> {
+            assertOK();
+            List<ModulePlatformsOutput> actualPlatforms = Arrays.asList(getBodyAsArray());
+            assertThat(actualPlatforms, hasSize(1));
         });
     }
 }

--- a/tests/bdd/src/test/java/org/hesperides/test/bdd/CucumberTests.java
+++ b/tests/bdd/src/test/java/org/hesperides/test/bdd/CucumberTests.java
@@ -26,7 +26,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 public class CucumberTests {
 
     @SpringBootTest(classes = {HesperidesSpringApplication.class, TestConfig.class}, webEnvironment = RANDOM_PORT)
-    @ActiveProfiles(profiles = {FAKE_MONGO, NOLDAP})
+    @ActiveProfiles(profiles = {FAKE_MONGO, NOLDAP, "test"})  // Ce dernier profil active la prise en compte du application-test.yml
     @Configuration
     @ContextConfiguration
     public static class SpringUnitTests {

--- a/tests/bdd/src/test/resources/application-test.yml
+++ b/tests/bdd/src/test/resources/application-test.yml
@@ -1,0 +1,9 @@
+logging.level:
+  org.hesperides.core:
+    application.files.FileValuationContext: DEBUG
+    domain:
+      templatecontainers.entities.AbstractProperty: DEBUG
+      modules.commands.ModuleAggregate: DEBUG
+      platforms.commands.PlatformAggregate: DEBUG
+  org.springframework:
+    data.mongodb.core.MongoTemplate: DEBUG

--- a/tests/bdd/src/test/resources/modules/search-modules.feature
+++ b/tests/bdd/src/test/resources/modules/search-modules.feature
@@ -51,7 +51,7 @@ Feature: Search modules
     When I search for some of those modules, limiting the number of results to 100
     Then the list of module results is limited to 12 items
 
-  # issue #595
+  #issue-595
   Scenario: search for modules an there is an exact match
     Given a list of 12 modules
     When I search for modules, using an existing module name and version

--- a/tests/bdd/src/test/resources/platforms/get-platforms-using-module.feature
+++ b/tests/bdd/src/test/resources/platforms/get-platforms-using-module.feature
@@ -9,3 +9,11 @@ Feature: Get platforms using module
     And an existing platform named "P2" with this module
     When I get the platforms using this module
     Then the platforms using this module are successfully retrieved
+
+  #issue-685
+  Scenario: get platforms using module
+    Given an existing module
+    And an existing platform named "P1" with this module
+    And an existing platform named "P2" with two modules : one with the same name and one with the same version
+    When I get the platforms using this module
+    Then a single platform is retrieved


### PR DESCRIPTION
J'en ai aussi profité pour injecter `$JAVA_OPTS` dans la commande de l'image Docker