### PR TITLE
Add: HTTP headers in responses for deprecated resources + fix FilesController.getFile resource path

### DIFF
--- a/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/ApplicationsController.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/ApplicationsController.java
@@ -73,7 +73,11 @@ public class ApplicationsController extends AbstractController {
     @PostMapping("/perform_search")
     @Deprecated
     public ResponseEntity<List<SearchResultOutput>> postSearchApplications(@RequestParam("name") String applicationName) {
-        return searchApplications(applicationName);
+        return ResponseEntity.ok()
+                .header("Deprecation", "version=\"2019-07-30\"")
+                .header("Sunset", "Wed Jul 31 00:00:00 CEST 2020")
+                .header("Link", "/perform_search")
+                .body(searchApplications(applicationName).getBody());
     }
 
     @ApiOperation("Search applications")

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/FilesController.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/FilesController.java
@@ -30,7 +30,7 @@ public class FilesController extends AbstractController {
     }
 
     @Deprecated
-    @ApiOperation("Get the list of files of an instance or a module")
+    @ApiOperation("Deprecated - Use GET /files/applications/{application_name}/platforms/{platform_name}/{module_path}/{module_name}/{module_version}/instances/{instance_name}/files instead")
     @GetMapping("files/applications/{application_name}/platforms/{platform_name}/{module_path}/{module_name}/{module_version}/instances/{instance_name}")
     public ResponseEntity<List<InstanceFileOutput>> getInstanceFilesDeprecated(@PathVariable("application_name") final String applicationName,
                                                                                @PathVariable("platform_name") final String platformName,
@@ -40,13 +40,16 @@ public class FilesController extends AbstractController {
                                                                                @PathVariable("instance_name") final String instanceName,
                                                                                @RequestParam("isWorkingCopy") final Boolean isWorkingCopy,
                                                                                @RequestParam(value = "simulate", required = false, defaultValue = "false") final String simulate) {
-
-        return getInstanceFiles(applicationName, platformName, modulePath, moduleName, moduleVersion, instanceName, isWorkingCopy, simulate);
+        return ResponseEntity.ok()
+                .header("Deprecation", "version=\"2019-09-24\"")
+                .header("Sunset", "Wed Sep 25 00:00:00 CEST 2020")
+                .header("Link", String.format("/applications/%s/platforms/%s/%s/%s/%s/instances/%s/files", applicationName, platformName, modulePath, moduleName, moduleVersion, instanceName))
+                .body(getInstanceFiles(applicationName, platformName, modulePath, moduleName, moduleVersion, instanceName, isWorkingCopy, simulate).getBody());
 
     }
 
     @Deprecated
-    @ApiOperation("Get a valued template file")
+    @ApiOperation("Deprecated - Use GET /files/applications/{application_name}/platforms/{platform_name}/{module_path}/{module_name}/{module_version}/instances/{instance_name}/files/{template_name} instead")
     @GetMapping(produces = MediaType.TEXT_PLAIN_VALUE + ";charset=UTF-8", path =
             "files/applications/{application_name}/platforms/{platform_name}/{module_path}/{module_name}/{module_version}/instances/{instance_name}/{template_name}")
     public ResponseEntity<String> getFileDeprecated(Authentication authentication,
@@ -61,7 +64,11 @@ public class FilesController extends AbstractController {
                                                     @RequestParam("template_namespace") final String templateNamespace,
                                                     @RequestParam(value = "simulate", required = false) final Boolean simulate) {
 
-        return getFile(authentication, applicationName, platformName, modulePath, moduleName, moduleVersion, instanceName, templateName, isWorkingCopy, templateNamespace, simulate);
+        return ResponseEntity.ok()
+                .header("Deprecation", "version=\"2019-09-24\"")
+                .header("Sunset", "Wed Sep 25 00:00:00 CEST 2020")
+                .header("Link", String.format("/applications/%s/platforms/%s/%s/%s/%s/instances/%s/files/%s", applicationName, platformName, modulePath, moduleName, moduleVersion, instanceName, templateName))
+                .body(getFile(authentication, applicationName, platformName, modulePath, moduleName, moduleVersion, instanceName, templateName, isWorkingCopy, templateNamespace, simulate).getBody());
     }
 
     @ApiOperation("Get the list of files of an instance or a module")
@@ -96,7 +103,7 @@ public class FilesController extends AbstractController {
 
     @ApiOperation("Get a valued template file")
     @GetMapping(produces = MediaType.TEXT_PLAIN_VALUE + ";charset=UTF-8", path =
-            "applications/{application_name}/platforms/{platform_name}/{module_path}/{module_name}/{module_version}/instances/{instance_name}/{template_name}/files")
+            "applications/{application_name}/platforms/{platform_name}/{module_path}/{module_name}/{module_version}/instances/{instance_name}/files/{template_name}")
     public ResponseEntity<String> getFile(Authentication authentication,
                                           @PathVariable("application_name") final String applicationName,
                                           @PathVariable("platform_name") final String platformName,

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/ModulesController.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/ModulesController.java
@@ -202,7 +202,11 @@ public class ModulesController extends AbstractController {
     @Deprecated
     public ResponseEntity<List<ModuleIO>> postSearch(@ApiParam(value = "Format: name (+ version)", required = true)
                                                      @RequestParam final String terms) {
-        return search(terms, 0);
+        return ResponseEntity.ok()
+                .header("Deprecation", "version=\"2019-04-23\"")
+                .header("Sunset", "Wed Apr 24 00:00:00 CEST 2020")
+                .header("Link", "/modules/perform_search")
+                .body(search(terms, 0).getBody());
     }
 
     @ApiOperation("Search for modules")
@@ -228,7 +232,11 @@ public class ModulesController extends AbstractController {
     @Deprecated
     public ResponseEntity<ModuleIO> postSearchSingle(@ApiParam(value = "Format: name (+ version) (+ true|false)", required = true)
                                                      @RequestParam final String terms) {
-        return searchSingle(terms);
+        return ResponseEntity.ok()
+                .header("Deprecation", "version=\"2019-04-23\"")
+                .header("Sunset", "Wed Apr 24 00:00:00 CEST 2020")
+                .header("Link", "/modules/perform_search")
+                .body(searchSingle(terms).getBody());
     }
 
     @ApiOperation("Search for a single module")

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/PlatformsController.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/PlatformsController.java
@@ -42,16 +42,20 @@ public class PlatformsController extends AbstractController {
         this.platformUseCases = platformUseCases;
     }
 
-    @PostMapping("/{application_name}/platforms")
-    @ApiOperation("Create platform")
     @Deprecated
+    @ApiOperation("Deprecated - Use POST /applications")
+    @PostMapping("/{application_name}/platforms")
     public ResponseEntity<PlatformIO> createPlatformOld(Authentication authentication,
                                                         @PathVariable("application_name") final String applicationName,
                                                         @RequestParam(value = "from_application", required = false) final String fromApplication,
                                                         @RequestParam(value = "from_platform", required = false) final String fromPlatform,
                                                         @RequestParam(value = "copy_instances_and_properties", defaultValue = "true", required = false) final boolean copyInstancesAndProperties,
                                                         @Valid @RequestBody final PlatformIO platformInput) {
-        return createPlatform(authentication, fromApplication, fromPlatform, copyInstancesAndProperties, platformInput);
+        return ResponseEntity.ok()
+                .header("Deprecation", "version=\"2019-05-03\"")
+                .header("Sunset", "Sat May  4 00:00:00 CEST 2020")
+                .header("Link", "/applications")
+                .body(createPlatform(authentication, fromApplication, fromPlatform, copyInstancesAndProperties, platformInput).getBody());
     }
 
     @PostMapping
@@ -158,12 +162,16 @@ public class PlatformsController extends AbstractController {
         return ResponseEntity.ok(modulePlatformsOutputs);
     }
 
+    @Deprecated
     @ApiOperation("Deprecated - Use GET /applications/platforms/perform_search instead")
     @PostMapping("/platforms/perform_search")
-    @Deprecated
     public ResponseEntity<List<SearchResultOutput>> postSearchPlatforms(@RequestParam("applicationName") final String applicationName,
                                                                         @RequestParam(value = "platformName", required = false) final String platformName) {
-        return searchPlatforms(applicationName, platformName);
+        return ResponseEntity.ok()
+                .header("Deprecation", "version=\"2019-04-23\"")
+                .header("Sunset", "Wed Apr 24 00:00:00 CEST 2020")
+                .header("Link", "/applications/platforms/perform_search")
+                .body(searchPlatforms(applicationName, platformName).getBody());
     }
 
     @ApiOperation("List platforms of a given application")

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/PropertiesController.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/PropertiesController.java
@@ -76,7 +76,11 @@ public class PropertiesController extends AbstractController {
                                                        @RequestParam("path") final String propertiesPath,
                                                        @RequestParam("platform_vid") final Long platformVersionId,
                                                        @Valid @RequestBody final PropertiesIO properties) {
-        return updateProperties(authentication, applicationName, platformName, propertiesPath, platformVersionId, properties);
+        return ResponseEntity.ok()
+                .header("Deprecation", "version=\"2019-08-02\"")
+                .header("Sunset", "Sat Aug  3 00:00:00 CEST 2020")
+                .header("Link", String.format("/applications/%s/platforms/%s/properties", applicationName, platformName))
+                .body(updateProperties(authentication, applicationName, platformName, propertiesPath, platformVersionId, properties).getBody());
     }
 
 

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/TechnosController.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/TechnosController.java
@@ -166,7 +166,11 @@ public class TechnosController extends AbstractController {
     @Deprecated
     public ResponseEntity<List<TechnoIO>> postSearch(@ApiParam(value = "Format: name (+ version)", required = true)
                                                      @RequestParam final String terms) {
-        return search(terms, 0);
+        return ResponseEntity.ok()
+                .header("Deprecation", "version=\"2019-04-24\"")
+                .header("Sunset", "Wed Apr 25 00:00:00 CEST 2020")
+                .header("Link", "/technos/perform_search")
+                .body(search(terms, 0).getBody());
     }
 
     @ApiOperation("Search for technos")


### PR DESCRIPTION
RFC: https://tools.ietf.org/html/draft-dalal-deprecation-header-00

Test effectué:
```
$ curl -vu user:password h -XPOST http://locaost:8080/rest/technos/perform_search?terms=toto
...
< Sunset: Wed Apr 25 00:00:00 CEST 2020
< Link: /technos/perform_search
< Deprecation: version="2019-04-24"
...
[]
```