### PR TITLE
Issue 803 : Permettre le nettoyage des propriétés inutilisées

### DIFF
--- a/core/application/src/main/java/org/hesperides/core/application/platforms/PlatformUseCases.java
+++ b/core/application/src/main/java/org/hesperides/core/application/platforms/PlatformUseCases.java
@@ -527,7 +527,7 @@ public class PlatformUseCases {
             throw new ForbiddenOperationException("Cleaning properties of a production platform is reserved to production role");
         }
         if (Platform.isGlobalPropertiesPath(propertiesPath)) {
-            throw new IllegalStateException("Cleaning only works on module properties (not global ones!)");
+            throw new IllegalArgumentException("Cleaning only works on module properties (not global ones!)");
         }
 
         final Module.Key moduleKey = Module.Key.fromPropertiesPath(propertiesPath);
@@ -537,14 +537,15 @@ public class PlatformUseCases {
                 .getDeployedModule(propertiesPath)
                 .getValuedProperties();
 
-        List<AbstractValuedProperty> filteredDomainValues = excludePropertyOutsideModel(baseValues, propertiesModel)
+        List<AbstractValuedProperty> filteredValuedProperties = excludePropertyOutsideModel(baseValues, propertiesModel)
                 .map(AbstractValuedPropertyView::toDomainValuedProperty)
                 .map(AbstractValuedProperty.class::cast)
                 .collect(Collectors.toList());
 
         Long propertiesVersionId = platformQueries.getPropertiesVersionId(platform.getId(), propertiesPath, null);
 
-        platformCommands.saveModulePropertiesInPlatform(platform.getId(), propertiesPath, platform.getVersionId(), propertiesVersionId, propertiesVersionId, filteredDomainValues, user);
+        platformCommands.saveModulePropertiesInPlatform(platform.getId(), propertiesPath, platform.getVersionId(),
+                propertiesVersionId, propertiesVersionId, filteredValuedProperties, user);
     }
 
     private static boolean containsDuplicateKeys(List<AbstractValuedProperty> list) {

--- a/core/application/src/main/java/org/hesperides/core/application/platforms/PlatformUseCases.java
+++ b/core/application/src/main/java/org/hesperides/core/application/platforms/PlatformUseCases.java
@@ -52,7 +52,7 @@ import static org.apache.logging.log4j.util.Strings.isBlank;
 import static org.hesperides.core.application.platforms.properties.PropertyType.GLOBAL;
 import static org.hesperides.core.application.platforms.properties.PropertyType.WITHOUT_MODEL;
 import static org.hesperides.core.application.platforms.properties.PropertyValuationBuilder.buildPropertyVisitorsSequenceForGlobals;
-import static org.hesperides.core.domain.platforms.queries.views.properties.AbstractValuedPropertyView.excludeUnusedProperties;
+import static org.hesperides.core.domain.platforms.queries.views.properties.AbstractValuedPropertyView.excludeUnusedValues;
 
 @Component
 public class PlatformUseCases {
@@ -539,9 +539,9 @@ public class PlatformUseCases {
 
         final List<AbstractPropertyView> propertiesModel = moduleQueries.getPropertiesModel(moduleKey);
         final List<AbstractValuedPropertyView> baseValues = deployedModule.getValuedProperties();
-        final Set<String> indirects = propertyReferenceScanner.findAll(baseValues, deployedModule.getInstances());
+        final Set<String> referencedProperties = propertyReferenceScanner.findAll(baseValues, deployedModule.getInstances());
 
-        List<AbstractValuedProperty> filteredValuedProperties = excludeUnusedProperties(baseValues, propertiesModel, indirects)
+        List<AbstractValuedProperty> filteredValuedProperties = excludeUnusedValues(baseValues, propertiesModel, referencedProperties)
                 .map(AbstractValuedPropertyView::toDomainValuedProperty)
                 .map(AbstractValuedProperty.class::cast)
                 .collect(Collectors.toList());

--- a/core/domain/src/main/java/org/hesperides/core/domain/modules/entities/Module.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/modules/entities/Module.java
@@ -97,15 +97,7 @@ public class Module extends TemplateContainer {
             if (parts.length < 3) {
                 throw new IllegalArgumentException("Too short properties path: " + propertiesPath);
             }
-            String lowercaseVersionType = parts[parts.length - 1].toLowerCase();
-            VersionType versionType;
-            if (VersionType.workingcopy.toString().equals(lowercaseVersionType)) {
-                versionType = VersionType.workingcopy;
-            } else if (VersionType.release.toString().equals(lowercaseVersionType)) {
-                versionType = VersionType.release;
-            } else {
-                throw new IllegalArgumentException("Invalid version type, must be WORKINGCOPY or RELEASE : " + parts[parts.length - 1]);
-            }
+            VersionType versionType = VersionType.of(parts[parts.length - 1]);
             return new Key(parts[parts.length - 3], parts[parts.length - 2], versionType);
         }
 

--- a/core/domain/src/main/java/org/hesperides/core/domain/modules/entities/Module.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/modules/entities/Module.java
@@ -97,7 +97,7 @@ public class Module extends TemplateContainer {
             if (parts.length < 3) {
                 throw new IllegalArgumentException("Too short properties path: " + propertiesPath);
             }
-            VersionType versionType = VersionType.of(parts[parts.length - 1]);
+            VersionType versionType = VersionType.fromName(parts[parts.length - 1]);
             return new Key(parts[parts.length - 3], parts[parts.length - 2], versionType);
         }
 

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/entities/properties/ValuedProperty.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/entities/properties/ValuedProperty.java
@@ -49,12 +49,15 @@ public class ValuedProperty extends AbstractValuedProperty {
     }
 
     public static List<String> extractValuesBetweenCurlyBrackets(String value) {
-        return Optional.ofNullable(value)
-                .map(notNullValue -> StringUtils.substringsBetween(notNullValue, "{{", "}}"))
+        return streamValuesBetweenCurlyBrackets(value)
+                .collect(Collectors.toList());
+    }
+
+    public static Stream<String> streamValuesBetweenCurlyBrackets(String value) {
+        return Optional.ofNullable(StringUtils.substringsBetween(value, "{{", "}}"))
                 .map(Arrays::stream)
                 .orElse(Stream.empty())
-                .map(String::trim)
-                .collect(Collectors.toList());
+                .map(String::trim);
     }
 
     /**

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/AbstractValuedPropertyView.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/AbstractValuedPropertyView.java
@@ -44,7 +44,8 @@ public abstract class AbstractValuedPropertyView {
 
     protected abstract Optional<AbstractValuedPropertyView> excludePropertyWithOnlyDefaultValue(Map<String, AbstractPropertyView> modelPerName);
 
-    protected abstract Optional<? extends AbstractValuedPropertyView> excludePropertyOutsideModel(Map<String, AbstractPropertyView> modelPerName);
+    protected abstract Optional<? extends AbstractValuedPropertyView> excludeUnusedProperty(
+            Map<String, AbstractPropertyView> modelPerName, Set<String> indirects);
 
     public static List<AbstractValuedProperty> toDomainAbstractValuedProperties(List<AbstractValuedPropertyView> valuedProperties) {
         return Optional.ofNullable(valuedProperties)
@@ -75,14 +76,19 @@ public abstract class AbstractValuedPropertyView {
 
     /**
      * Récupère de manière récursive les propriétés en excluant les propriétés valorisées
-     * mais n'étant plus définie dans le modèle qu'elles illustrent
+     * mais n'étant plus
+     * <ul>
+     * <li>ni définie dans le modèle qu'elles illustrent.
+     * <li>ni utilisée par une autre valorisation (incluant les variables d'instances ou itérables)
+     * </ul>
      */
-    public static Stream<AbstractValuedPropertyView> excludePropertyOutsideModel(List<AbstractValuedPropertyView> valuedProperties,
-                                                                                 List<AbstractPropertyView> propertiesModel) {
+    public static Stream<AbstractValuedPropertyView> excludeUnusedProperties(List<AbstractValuedPropertyView> valuedProperties,
+                                                                             List<AbstractPropertyView> propertiesModel,
+                                                                             Set<String> indirects) {
         Map<String, AbstractPropertyView> perName = modelsPerName(propertiesModel);
 
         return valuedProperties.stream()
-                .map(valuedProperty -> valuedProperty.excludePropertyOutsideModel(perName))
+                .map(valuedProperty -> valuedProperty.excludeUnusedProperty(perName, indirects))
                 .filter(Optional::isPresent)
                 .map(Optional::get);
     }

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/IterablePropertyItemView.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/IterablePropertyItemView.java
@@ -62,8 +62,8 @@ public class IterablePropertyItemView {
         return new IterablePropertyItemView(title, AbstractValuedPropertyView.excludePropertiesWithOnlyDefaultValue(abstractValuedPropertyViews, propertiesModel));
     }
 
-    IterablePropertyItemView excludeUnusedProperties(List<AbstractPropertyView> propertiesModel, Set<String> indirections) {
-        final List<AbstractValuedPropertyView> surviving = AbstractValuedPropertyView.excludeUnusedProperties(
+    IterablePropertyItemView excludeUnusedValues(List<AbstractPropertyView> propertiesModel, Set<String> indirections) {
+        final List<AbstractValuedPropertyView> surviving = AbstractValuedPropertyView.excludeUnusedValues(
                 abstractValuedPropertyViews, propertiesModel, indirections).collect(toList());
 
         return new IterablePropertyItemView(title, surviving);

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/IterablePropertyItemView.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/IterablePropertyItemView.java
@@ -28,9 +28,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static org.hesperides.core.domain.platforms.queries.views.properties.AbstractValuedPropertyView.toDomainAbstractValuedProperties;
+
+import static java.util.stream.Collectors.toList;
 
 @Value
 public class IterablePropertyItemView {
@@ -45,7 +46,7 @@ public class IterablePropertyItemView {
     public IterablePropertyItemView withPasswordsHidden(Predicate<String> isPassword) {
         return new IterablePropertyItemView(title, abstractValuedPropertyViews.stream()
                 .map(property -> property.withPasswordsHidden(isPassword))
-                .collect(Collectors.toList()));
+                .collect(toList()));
     }
 
     public static List<IterablePropertyItem> toDomainIterablePropertyItems(List<IterablePropertyItemView> iterablePropertyItems) {
@@ -53,10 +54,14 @@ public class IterablePropertyItemView {
                 .orElseGet(Collections::emptyList)
                 .stream()
                 .map(IterablePropertyItemView::toDomainIterablePropertyItem)
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     IterablePropertyItemView excludePropertyWithOnlyDefaultValue(List<AbstractPropertyView> propertiesModel) {
         return new IterablePropertyItemView(title, AbstractValuedPropertyView.excludePropertiesWithOnlyDefaultValue(abstractValuedPropertyViews, propertiesModel));
+    }
+
+    IterablePropertyItemView excludePropertyOutsideModel(List<AbstractPropertyView> propertiesModel) {
+        return new IterablePropertyItemView(title, AbstractValuedPropertyView.excludePropertyOutsideModel(abstractValuedPropertyViews, propertiesModel).collect(toList()));
     }
 }

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/IterablePropertyItemView.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/IterablePropertyItemView.java
@@ -27,6 +27,7 @@ import org.hesperides.core.domain.templatecontainers.queries.AbstractPropertyVie
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import static org.hesperides.core.domain.platforms.queries.views.properties.AbstractValuedPropertyView.toDomainAbstractValuedProperties;
@@ -61,7 +62,10 @@ public class IterablePropertyItemView {
         return new IterablePropertyItemView(title, AbstractValuedPropertyView.excludePropertiesWithOnlyDefaultValue(abstractValuedPropertyViews, propertiesModel));
     }
 
-    IterablePropertyItemView excludePropertyOutsideModel(List<AbstractPropertyView> propertiesModel) {
-        return new IterablePropertyItemView(title, AbstractValuedPropertyView.excludePropertyOutsideModel(abstractValuedPropertyViews, propertiesModel).collect(toList()));
+    IterablePropertyItemView excludeUnusedProperties(List<AbstractPropertyView> propertiesModel, Set<String> indirections) {
+        final List<AbstractValuedPropertyView> surviving = AbstractValuedPropertyView.excludeUnusedProperties(
+                abstractValuedPropertyViews, propertiesModel, indirections).collect(toList());
+
+        return new IterablePropertyItemView(title, surviving);
     }
 }

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/IterableValuedPropertyView.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/IterableValuedPropertyView.java
@@ -29,6 +29,7 @@ import org.hesperides.core.domain.templatecontainers.queries.IterablePropertyVie
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -64,14 +65,15 @@ public class IterableValuedPropertyView extends AbstractValuedPropertyView {
     }
 
     @Override
-    protected Optional<AbstractValuedPropertyView> excludePropertyOutsideModel(Map<String, AbstractPropertyView> modelPerName) {
+    protected Optional<AbstractValuedPropertyView> excludeUnusedProperty(
+            Map<String, AbstractPropertyView> modelPerName, Set<String> indirects) {
         List<AbstractPropertyView> propertiesModel = findPropertiesModel(modelPerName);
 
-        List<IterablePropertyItemView> items = iterablePropertyItems.stream()
-                .map(item -> item.excludePropertyOutsideModel(propertiesModel))
+        List<IterablePropertyItemView> survivingItems = iterablePropertyItems.stream()
+                .map(item -> item.excludeUnusedProperties(propertiesModel, indirects))
                 .collect(Collectors.toList());
 
-        return Optional.of(new IterableValuedPropertyView(getName(), items));
+        return Optional.of(new IterableValuedPropertyView(getName(), survivingItems));
     }
 
     private List<AbstractPropertyView> findPropertiesModel(Map<String, AbstractPropertyView> modelPerName) {

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/PropertyReferenceScanner.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/PropertyReferenceScanner.java
@@ -1,0 +1,52 @@
+package org.hesperides.core.domain.platforms.queries.views.properties;
+
+import static org.hesperides.core.domain.platforms.entities.properties.ValuedProperty.streamValuesBetweenCurlyBrackets;
+import org.hesperides.core.domain.platforms.queries.views.InstanceView;
+
+import org.springframework.stereotype.Component;
+
+import static java.util.stream.Collectors.toSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+@Component
+public class PropertyReferenceScanner {
+
+    public Set<String> findAll(List<AbstractValuedPropertyView> moduleProperties, List<InstanceView> instances) {
+        final Stream<String> inModule = moduleProperties.stream()
+                .flatMap(this::scan);
+
+        final Stream<String> inInstances = instances.stream()
+                .flatMap(instance -> instance.getValuedProperties().stream())
+                .flatMap(this::fromSimple);
+
+        return Stream.concat(inModule, inInstances).collect(toSet());
+    }
+
+    private Stream<String> fromIterable(IterableValuedPropertyView iterable) {
+        return iterable.getIterablePropertyItems().stream()
+                .flatMap(item -> item.getAbstractValuedPropertyViews().stream())
+                .flatMap(this::scan); // récursion, mon amour ;)
+    }
+
+    private Stream<String> fromSimple(ValuedPropertyView simple) {
+        return streamValuesBetweenCurlyBrackets(simple.getValue());
+    }
+
+    private Stream<String> scan(AbstractValuedPropertyView valuedProperty) {
+        final Stream<String> references;
+
+        if (valuedProperty instanceof ValuedPropertyView) {
+            references = fromSimple((ValuedPropertyView) valuedProperty);
+
+        } else if (valuedProperty instanceof IterableValuedPropertyView) {
+            references = fromIterable((IterableValuedPropertyView) valuedProperty);
+
+        } else {
+            references = Stream.empty();
+        }
+
+        return references;
+    }
+}

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/ValuedPropertyView.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/ValuedPropertyView.java
@@ -29,8 +29,8 @@ import org.hesperides.core.domain.templatecontainers.queries.PropertyView;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -62,9 +62,9 @@ public class ValuedPropertyView extends AbstractValuedPropertyView {
     }
 
     @Override
-    protected Optional<AbstractValuedPropertyView> excludePropertyWithOnlyDefaultValue(Function<String, AbstractPropertyView> modelFinder) {
+    protected Optional<AbstractValuedPropertyView> excludePropertyWithOnlyDefaultValue(Map<String, AbstractPropertyView> modelPerName) {
         if (StringUtils.isEmpty(value)) {
-            PropertyView model = (PropertyView) modelFinder.apply(getName());
+            PropertyView model = (PropertyView) modelPerName.get(getName());
             if (model != null && StringUtils.isNotEmpty(model.getDefaultValue())) {
                 return Optional.empty();
             }
@@ -74,9 +74,9 @@ public class ValuedPropertyView extends AbstractValuedPropertyView {
     }
 
     @Override
-    protected Optional<? extends AbstractValuedPropertyView> excludePropertyOutsideModel(Function<String, AbstractPropertyView> modelFinder) {
+    protected Optional<? extends AbstractValuedPropertyView> excludePropertyOutsideModel(Map<String, AbstractPropertyView> modelPerName) {
         return Optional.of(this)
-                .filter(instance -> modelFinder.apply(getName()) != null);
+                .filter(instance -> modelPerName.containsKey(getName()));
     }
 
     public static List<ValuedProperty> toDomainValuedProperties(List<ValuedPropertyView> valuedProperties) {

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/ValuedPropertyView.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/ValuedPropertyView.java
@@ -30,6 +30,7 @@ import org.hesperides.core.domain.templatecontainers.queries.PropertyView;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -61,12 +62,21 @@ public class ValuedPropertyView extends AbstractValuedPropertyView {
     }
 
     @Override
-    protected Optional<AbstractValuedPropertyView> excludePropertyWithOnlyDefaultValue(AbstractPropertyView propertyModel) {
-        if (StringUtils.isNotEmpty(value)) {
-            return Optional.of(this);
+    protected Optional<AbstractValuedPropertyView> excludePropertyWithOnlyDefaultValue(Function<String, AbstractPropertyView> modelFinder) {
+        if (StringUtils.isEmpty(value)) {
+            PropertyView model = (PropertyView) modelFinder.apply(getName());
+            if (model != null && StringUtils.isNotEmpty(model.getDefaultValue())) {
+                return Optional.empty();
+            }
         }
-        PropertyView singlePropertyModel = (PropertyView) propertyModel;
-        return singlePropertyModel == null || StringUtils.isEmpty(singlePropertyModel.getDefaultValue()) ? Optional.of(this) : Optional.empty();
+
+        return Optional.of(this);
+    }
+
+    @Override
+    protected Optional<? extends AbstractValuedPropertyView> excludePropertyOutsideModel(Function<String, AbstractPropertyView> modelFinder) {
+        return Optional.of(this)
+                .filter(instance -> modelFinder.apply(getName()) != null);
     }
 
     public static List<ValuedProperty> toDomainValuedProperties(List<ValuedPropertyView> valuedProperties) {

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/ValuedPropertyView.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/ValuedPropertyView.java
@@ -75,10 +75,10 @@ public class ValuedPropertyView extends AbstractValuedPropertyView {
     }
 
     @Override
-    protected Optional<? extends AbstractValuedPropertyView> excludeUnusedProperty(
-            Map<String, AbstractPropertyView> modelPerName, Set<String> indirects) {
+    protected Optional<? extends AbstractValuedPropertyView> excludeUnusedValue(
+            Map<String, AbstractPropertyView> propertiesPerName, Set<String> referencedProperties) {
         return Optional.of(this)
-                .filter(instance -> modelPerName.containsKey(getName()) || indirects.contains(getName()));
+                .filter(instance -> propertiesPerName.containsKey(getName()) || referencedProperties.contains(getName()));
     }
 
     public static List<ValuedProperty> toDomainValuedProperties(List<ValuedPropertyView> valuedProperties) {

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/ValuedPropertyView.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/properties/ValuedPropertyView.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -74,9 +75,10 @@ public class ValuedPropertyView extends AbstractValuedPropertyView {
     }
 
     @Override
-    protected Optional<? extends AbstractValuedPropertyView> excludePropertyOutsideModel(Map<String, AbstractPropertyView> modelPerName) {
+    protected Optional<? extends AbstractValuedPropertyView> excludeUnusedProperty(
+            Map<String, AbstractPropertyView> modelPerName, Set<String> indirects) {
         return Optional.of(this)
-                .filter(instance -> modelPerName.containsKey(getName()));
+                .filter(instance -> modelPerName.containsKey(getName()) || indirects.contains(getName()));
     }
 
     public static List<ValuedProperty> toDomainValuedProperties(List<ValuedPropertyView> valuedProperties) {

--- a/core/domain/src/main/java/org/hesperides/core/domain/templatecontainers/entities/TemplateContainer.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/templatecontainers/entities/TemplateContainer.java
@@ -87,13 +87,25 @@ public abstract class TemplateContainer {
         }
 
         public static VersionType fromMinimizedForm(final String minimizedForm) {
-            return Stream.of(VersionType.values()).filter(v -> v.minimizedForm.equals(minimizedForm))
-                    .findFirst()
-                    .orElseThrow(() -> new InvalidParameterException(String.format("No minimized form of VersionType found for %s", minimizedForm)));
+            for (VersionType v : VersionType.values()) {
+                if (v.minimizedForm.equalsIgnoreCase(minimizedForm)) {
+                    return v;
+                }
+            }
+            throw new InvalidParameterException("No minimized form of VersionType found for " + minimizedForm);
+        }
+
+        public static VersionType of(String name) {
+            for (VersionType v : VersionType.values()) {
+                if (v.name().equalsIgnoreCase(name)) {
+                    return v;
+                }
+            }
+            throw new IllegalArgumentException("Invalid version type, must be WORKINGCOPY or RELEASE : " + name);
         }
 
         public static String toString(boolean isWorkingCopy) {
-            return isWorkingCopy ? workingcopy.toString() : release.toString();
+            return getVersionType(isWorkingCopy).toString();
         }
     }
 

--- a/core/domain/src/main/java/org/hesperides/core/domain/templatecontainers/entities/TemplateContainer.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/templatecontainers/entities/TemplateContainer.java
@@ -87,18 +87,18 @@ public abstract class TemplateContainer {
         }
 
         public static VersionType fromMinimizedForm(final String minimizedForm) {
-            for (VersionType v : VersionType.values()) {
-                if (v.minimizedForm.equalsIgnoreCase(minimizedForm)) {
-                    return v;
+            for (VersionType versionType : VersionType.values()) {
+                if (versionType.minimizedForm.equalsIgnoreCase(minimizedForm)) {
+                    return versionType;
                 }
             }
             throw new InvalidParameterException("No minimized form of VersionType found for " + minimizedForm);
         }
 
-        public static VersionType of(String name) {
-            for (VersionType v : VersionType.values()) {
-                if (v.name().equalsIgnoreCase(name)) {
-                    return v;
+        public static VersionType fromName(String name) {
+            for (VersionType versionType : VersionType.values()) {
+                if (versionType.name().equalsIgnoreCase(name)) {
+                    return versionType;
                 }
             }
             throw new IllegalArgumentException("Invalid version type, must be WORKINGCOPY or RELEASE : " + name);

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/PropertiesController.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/PropertiesController.java
@@ -120,18 +120,20 @@ public class PropertiesController extends AbstractController {
 
     @ApiOperation("Purge properties that are no longer needed by related templates")
     @DeleteMapping("/{application_name}/platforms/{platform_name}/properties/clean_unused_properties")
-    public ResponseEntity<Void> cleanUnusedProperties(Authentication authentication,
+    public ResponseEntity cleanUnusedProperties(Authentication authentication,
                                                       @PathVariable("application_name") String applicationName,
                                                       @PathVariable("platform_name") String platformName,
-                                                      @RequestParam(value = "properties_path", required = false) String path) {
+                                                      @RequestParam(value = "properties_path", required = false) String propertiesPath) {
         Platform.Key platformKey = new Platform.Key(applicationName, platformName);
         User authenticatedUser = new User(authentication);
 
-        if (StringUtils.isEmpty(path) || "#".equals(path)) {
+        if (StringUtils.isEmpty(propertiesPath)) {
+            // tous les modules
             platformUseCases.getPlatform(platformKey).getActiveDeployedModules()
                     .forEach(module -> platformUseCases.purgeUnusedProperties(platformKey, module.getPropertiesPath(), authenticatedUser));
         } else {
-            platformUseCases.purgeUnusedProperties(platformKey, path, authenticatedUser);
+            // un seul module
+            platformUseCases.purgeUnusedProperties(platformKey, propertiesPath, authenticatedUser);
         }
 
         return ResponseEntity.noContent().build();

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/PropertiesController.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/PropertiesController.java
@@ -17,6 +17,8 @@ import org.hesperides.core.presentation.io.platforms.properties.GlobalPropertyUs
 import org.hesperides.core.presentation.io.platforms.properties.PropertiesIO;
 import org.hesperides.core.presentation.io.platforms.properties.PropertiesWithDetailsOutput;
 import org.hesperides.core.presentation.io.platforms.properties.diff.PropertiesDiffOutput;
+
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -114,6 +116,25 @@ public class PropertiesController extends AbstractController {
         List<AbstractValuedPropertyView> propertyViews = platformUseCases.saveProperties(platformKey, propertiesPath, platformVersionId, abstractValuedProperties, properties.getPropertiesVersionId(), new User(authentication));
         Long propertiesVersionId = platformUseCases.getPropertiesVersionId(platformKey, propertiesPath);
         return ResponseEntity.ok(new PropertiesIO(propertiesVersionId, propertyViews));
+    }
+
+    @ApiOperation("Purge properties that are no longer needed by related templates")
+    @DeleteMapping("/{application_name}/platforms/{platform_name}/properties/clean_unused_properties")
+    public ResponseEntity<Void> cleanUnusedProperties(Authentication authentication,
+                                                      @PathVariable("application_name") String applicationName,
+                                                      @PathVariable("platform_name") String platformName,
+                                                      @RequestParam(value = "properties_path", required = false) String path) {
+        Platform.Key platformKey = new Platform.Key(applicationName, platformName);
+        User authenticatedUser = new User(authentication);
+
+        if (StringUtils.isEmpty(path) || "#".equals(path)) {
+            platformUseCases.getPlatform(platformKey).getActiveDeployedModules()
+                    .forEach(module -> platformUseCases.purgeUnusedProperties(platformKey, module.getPropertiesPath(), authenticatedUser));
+        } else {
+            platformUseCases.purgeUnusedProperties(platformKey, path, authenticatedUser);
+        }
+
+        return ResponseEntity.noContent().build();
     }
 
     @ApiOperation("Get properties diff with the given paths in given platforms")

--- a/documentation/lightweight-architecture-decision-records/clean_unused_properties.md
+++ b/documentation/lightweight-architecture-decision-records/clean_unused_properties.md
@@ -1,0 +1,11 @@
+# Nettoyage des propriétés inutilisées
+
+Lorsqu'une propriété est valorisée mais ne correspond à aucune propriété du modèle (déclarée dans un template), on considère qu'elle est inutilisée.
+
+Aujourd'hui le front permet de supprimer ces propriétés au niveau d'un module déployé. Nous souhaitons porter cette fonctionnalité dans le backend et permettre de nettoyer ces propriétés aussi pour l'ensemble des modules déployés d'une plateforme.
+
+Voici le endpoint proposé :
+
+    DELETE /applications/{application_name}/platforms/{platform_name}/properties/clean_unused_properties?properties_path={properties_path}
+    
+Le paramètre de requête `properties_path` est facultatif.

--- a/documentation/lightweight-architecture-decision-records/clean_unused_properties.md
+++ b/documentation/lightweight-architecture-decision-records/clean_unused_properties.md
@@ -1,11 +1,40 @@
 # Nettoyage des propriétés inutilisées
 
-Lorsqu'une propriété est valorisée mais ne correspond à aucune propriété du modèle (déclarée dans un template), on considère qu'elle est inutilisée.
+Lorsqu'une propriété est valorisée mais ne correspond à aucune propriété du modèle (déclarée dans un template)
+**et** qu'elle n'est référecée dans aucune autre valorisation, on considère qu'elle est inutilisée.
 
-Aujourd'hui le front permet de supprimer ces propriétés au niveau d'un module déployé. Nous souhaitons porter cette fonctionnalité dans le backend et permettre de nettoyer ces propriétés aussi pour l'ensemble des modules déployés d'une plateforme.
+En effet, nous souhaitons conserver la possibilité de factoriser une valeur commune au sein d'une propriété "fictive".
 
-Voici le endpoint proposé :
+Aujourd'hui le _front_ permet de supprimer ces propriétés au niveau d'un module déployé.
+Nous souhaitons porter cette fonctionnalité dans le backend et permettre de nettoyer ces propriétés aussi pour l'ensemble des modules déployés d'une plateforme.
+
+Voici le endpoint :
 
     DELETE /applications/{application_name}/platforms/{platform_name}/properties/clean_unused_properties?properties_path={properties_path}
     
 Le paramètre de requête `properties_path` est facultatif.
+Il permettra, entre autre, de décommissionner le code du _front_.
+
+## exemple de propriété "fictive"
+
+Soit un module définissant le fichier `env.yml` suivant
+```yaml
+facade:
+  enpointA: {{url.a}}
+  enpointB: {{url.b}}
+```
+et la plateforme `INT1` utilisant ce module comme suit :
+
+| nom        | valeur                      |
+|------------|-----------------------------|
+| `base_url` | http://10.1.0.201           |
+| `root`     | https://external.cc         |
+| `url.a`    | `{{base_url}}`/a_path       |
+| `url.b`    | `{{base_url}}`/another_path |
+| `url.c`    | `{{root}}`/old_path         |
+
+Son nettoyage provoquerait la disparition de `url.c` **uniquement**, car 
+* `base_url`, bien que n'appartenant pas au modèle, est référencée dans la valorisation d'`url.a` et`url.b`
+* `root` est également référencée, fut-ce dans une valorisation qui va être nettoyée (ce que le code ne sait pas)
+
+On en déduit que dans un tel cas, il faudra plusieurs appels pour "tout nettoyer".

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/modules/scenarios/CreateModules.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/modules/scenarios/CreateModules.java
@@ -2,6 +2,7 @@ package org.hesperides.test.bdd.modules.scenarios;
 
 import cucumber.api.java.en.Given;
 import cucumber.api.java8.En;
+
 import org.hesperides.core.presentation.io.ModuleIO;
 import org.hesperides.test.bdd.commons.HesperidesScenario;
 import org.hesperides.test.bdd.modules.ModuleBuilder;
@@ -11,6 +12,7 @@ import org.hesperides.test.bdd.technos.TechnoBuilder;
 import org.hesperides.test.bdd.templatecontainers.builders.PropertyBuilder;
 import org.hesperides.test.bdd.templatecontainers.builders.TemplateBuilder;
 import org.hesperides.test.bdd.users.UserAuthorities;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -134,20 +136,30 @@ public class CreateModules extends HesperidesScenario implements En {
         }
     }
 
-    public CreateModules() {
+    /**
+     * Cette étape est la fusion de 2 glues :
+     * <ul>
+     * <li>{@code Given a template with the following content}
+     * <li>{@code Given a module with this template}
+     * </ul>
+     * il y a 59 tests qui dépendent de cette étape.
+     */
+    @Given("^an existing module(?: named \"([^\"]*)\")?(?: with version \"([^\"]*)\")? with this template content$")
+    public void givenModuleWithTemplateContent(String moduleName, String moduleVersion, String templateContent) {
+        moduleBuilder.reset();
+        if (isNotEmpty(moduleName)) {
+            moduleBuilder.withName(moduleName);
+        }
+        if (isNotEmpty(moduleVersion)) {
+            moduleBuilder.withVersion(moduleVersion);
+        }
+        createModule();
+        templateBuilder.setContent(templateContent);
+        addTemplatePropertiesToModuleBuilder(templateBuilder);
+        addTemplateToModule();
+    }
 
-        Given("^an existing module(?: with version \"([^\"]*)\")? with this template content$", (String moduleVersion, String templateContent) -> {
-            // Cette étape est la fusion de `Given a template with the following content` et de
-            // `Given a module with this template`, il y a 59 tests qui dépendent de cette étape.
-            moduleBuilder.reset();
-            if (isNotEmpty(moduleVersion)) {
-                moduleBuilder.withVersion(moduleVersion);
-            }
-            createModule();
-            templateBuilder.setContent(templateContent);
-            addTemplatePropertiesToModuleBuilder(templateBuilder);
-            addTemplateToModule();
-        });
+    public CreateModules() {
 
         Given("^a module with (\\d+) versions$", (Integer nbVersions) -> {
             IntStream.range(0, nbVersions).forEach(index -> {

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/modules/scenarios/CreateModules.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/modules/scenarios/CreateModules.java
@@ -136,30 +136,28 @@ public class CreateModules extends HesperidesScenario implements En {
         }
     }
 
-    /**
-     * Cette étape est la fusion de 2 glues :
-     * <ul>
-     * <li>{@code Given a template with the following content}
-     * <li>{@code Given a module with this template}
-     * </ul>
-     * il y a 59 tests qui dépendent de cette étape.
-     */
-    @Given("^an existing module(?: named \"([^\"]*)\")?(?: with version \"([^\"]*)\")? with this template content$")
-    public void givenModuleWithTemplateContent(String moduleName, String moduleVersion, String templateContent) {
-        moduleBuilder.reset();
-        if (isNotEmpty(moduleName)) {
-            moduleBuilder.withName(moduleName);
-        }
-        if (isNotEmpty(moduleVersion)) {
-            moduleBuilder.withVersion(moduleVersion);
-        }
-        createModule();
-        templateBuilder.setContent(templateContent);
-        addTemplatePropertiesToModuleBuilder(templateBuilder);
-        addTemplateToModule();
-    }
-
     public CreateModules() {
+
+        /*
+         * Cette étape est la fusion de 2 glues :
+         * - {@code Given a template with the following content}
+         * - {@code Given a module with this template}
+         *
+         * il y a 61 tests qui dépendent de cette étape.
+         */
+        Given("^an existing module(?: named \"([^\"]*)\")?(?: with version \"([^\"]*)\")? with this template content$", (String moduleName, String moduleVersion, String templateContent) -> {
+            moduleBuilder.reset();
+            if (isNotEmpty(moduleName)) {
+                moduleBuilder.withName(moduleName);
+            }
+            if (isNotEmpty(moduleVersion)) {
+                moduleBuilder.withVersion(moduleVersion);
+            }
+            createModule();
+            templateBuilder.setContent(templateContent);
+            addTemplatePropertiesToModuleBuilder(templateBuilder);
+            addTemplateToModule();
+        });
 
         Given("^a module with (\\d+) versions$", (Integer nbVersions) -> {
             IntStream.range(0, nbVersions).forEach(index -> {

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/PlatformClient.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/PlatformClient.java
@@ -149,10 +149,10 @@ public class PlatformClient {
         return testContext.getResponseBody();
     }
 
-    public void cleanUnusedProperties(PlatformIO platformInput, String propertiesPath) {
+    public void cleanUnusedProperties(PlatformIO platformInput, String propertiesPath, String tryTo) {
         restTemplate.deleteForEntity(
                 "/applications/{application_name}/platforms/{platform_name}/properties/clean_unused_properties?properties_path={path}",
-                Void.class,
+                getResponseType(tryTo, Void.class),
                 platformInput.getApplicationName(),
                 platformInput.getPlatformName(),
                 propertiesPath

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/PlatformClient.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/PlatformClient.java
@@ -149,6 +149,16 @@ public class PlatformClient {
         return testContext.getResponseBody();
     }
 
+    public void cleanUnusedProperties(PlatformIO platformInput, String propertiesPath) {
+        restTemplate.deleteForEntity(
+                "/applications/{application_name}/platforms/{platform_name}/properties/clean_unused_properties?properties_path={path}",
+                Void.class,
+                platformInput.getApplicationName(),
+                platformInput.getPlatformName(),
+                propertiesPath
+        );
+    }
+
     public void saveGlobalProperties(PlatformIO platform, PropertiesIO propertiesInput) {
         saveProperties(platform, propertiesInput, "#");
     }

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/builders/DeployedModuleBuilder.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/builders/DeployedModuleBuilder.java
@@ -46,6 +46,7 @@ public class DeployedModuleBuilder implements Serializable {
     @Getter
     @Setter
     private Long propertiesVersionId;
+    @Getter
     private String name;
     @Getter
     private String version;

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/builders/PlatformBuilder.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/builders/PlatformBuilder.java
@@ -287,6 +287,13 @@ public class PlatformBuilder implements Serializable {
         return new Platform.Key(applicationName, platformName);
     }
 
+    public DeployedModuleBuilder findDeployedModuleBuilderByName(String moduleName) {
+        return deployedModuleBuilders.stream()
+                .filter(builder -> moduleName.equals(builder.getName()))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Can't find deployed module with name \"" + moduleName + "\""));
+    }
+
     public DeployedModuleBuilder findDeployedModuleBuilderByVersion(String moduleVersion) {
         return deployedModuleBuilders.stream()
                 .filter(deployedModuleBuilder -> moduleVersion.equals(deployedModuleBuilder.getVersion()))

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/PurgeProperties.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/PurgeProperties.java
@@ -1,0 +1,42 @@
+package org.hesperides.test.bdd.platforms.scenarios;
+
+import org.hesperides.core.presentation.io.platforms.PlatformIO;
+import org.hesperides.core.presentation.io.platforms.properties.PropertiesIO;
+import org.hesperides.test.bdd.commons.HesperidesScenario;
+import org.hesperides.test.bdd.platforms.PlatformClient;
+import org.hesperides.test.bdd.platforms.builders.DeployedModuleBuilder;
+import org.hesperides.test.bdd.platforms.builders.PlatformBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import cucumber.api.DataTable;
+import cucumber.api.java8.En;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+public class PurgeProperties extends HesperidesScenario implements En {
+
+    @Autowired
+    private PlatformClient platformClient;
+    @Autowired
+    private PlatformBuilder platformBuilder;
+
+    public PurgeProperties() {
+        When("I purge unneeded properties(?: on path \"([^\"]+)\")?", (String path) -> {
+            PlatformIO input = platformBuilder.buildInput();
+            platformClient.cleanUnusedProperties(input, path);
+        });
+
+        Then("module \"([^\"]+)\" contains only the following properties", (String moduleName, DataTable propertyNames) -> {
+            List<String> expectedNames = propertyNames.asList(String.class);
+
+            PlatformIO selector = platformBuilder.buildInput();
+            DeployedModuleBuilder moduleBuilder = platformBuilder.findDeployedModuleBuilderByName(moduleName);
+
+            PropertiesIO output = platformClient.getProperties(selector, moduleBuilder.buildPropertiesPath());
+
+            assertThat(output.getValuedProperties()).hasSize(expectedNames.size())
+                    .allSatisfy(valueProperty -> assertThat(valueProperty.getName()).isIn(expectedNames));
+        });
+    }
+}

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/PurgeProperties.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/PurgeProperties.java
@@ -22,12 +22,28 @@ public class PurgeProperties extends HesperidesScenario implements En {
     private PlatformBuilder platformBuilder;
 
     public PurgeProperties() {
-        When("I purge unneeded properties(?: on path \"([^\"]+)\")?", (String path) -> {
-            PlatformIO input = platformBuilder.buildInput();
-            platformClient.cleanUnusedProperties(input, path);
+        When("I try to purge unneeded global properties of this platform", () -> {
+            PlatformIO selector = platformBuilder.buildInput();
+
+            platformClient.cleanUnusedProperties(selector, "#", "should fail");
         });
 
-        Then("module \"([^\"]+)\" contains only the following properties", (String moduleName, DataTable propertyNames) -> {
+        When("I purge unneeded properties (?:of this platform|of module \"([^\"]+)\")", (String moduleName) -> {
+            PlatformIO selector = platformBuilder.buildInput();
+            String path = moduleName == null ? null
+                    : platformBuilder.findDeployedModuleBuilderByName(moduleName).buildPropertiesPath();
+
+            platformClient.cleanUnusedProperties(selector, path, null);
+        });
+
+        When("I try to purge unneeded properties of unknown module \"([^\"]+)\"", (String badModuleName) -> {
+            PlatformIO selector = platformBuilder.buildInput();
+            String path = "#ABC#DEF#" + badModuleName + "#1.0#RELEASE";
+
+            platformClient.cleanUnusedProperties(selector, path, "should fail");
+        });
+
+        Then("the module \"([^\"]+)\" (?:contains only|still contains all) the following properties", (String moduleName, DataTable propertyNames) -> {
             List<String> expectedNames = propertyNames.asList(String.class);
 
             PlatformIO selector = platformBuilder.buildInput();

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/SaveProperties.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/SaveProperties.java
@@ -116,8 +116,8 @@ public class SaveProperties extends HesperidesScenario implements En {
         saveValuedProperties(null, deployedModuleBuilder);
     }
 
-    void saveValuedProperties(DeployedModuleBuilder moduleBuilder) {
-        saveValuedProperties(null, moduleBuilder);
+    void saveValuedProperties(DeployedModuleBuilder deployedModuleBuilder) {
+        saveValuedProperties(null, deployedModuleBuilder);
     }
 
     private void saveValuedProperties(String tryTo, DeployedModuleBuilder deployedModuleBuilder) {

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/SaveProperties.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/SaveProperties.java
@@ -72,12 +72,12 @@ public class SaveProperties extends HesperidesScenario implements En {
 
         When("^I( try to)? save these properties$", (String tryTo, DataTable data) -> {
             deployedModuleBuilder.setValuedProperties(data.asList(ValuedPropertyIO.class));
-            saveValuedProperties(tryTo);
+            saveValuedProperties(tryTo, deployedModuleBuilder);
         });
 
         When("^I( try to)? save these iterable properties$", (String tryTo, DataTable data) -> {
             deployedModuleBuilder.setIterableProperties(dataTableToIterableProperties(data));
-            saveValuedProperties(tryTo);
+            saveValuedProperties(tryTo, deployedModuleBuilder);
         });
 
         Then("^the( global)? properties are successfully (?:sav|updat)ed$", (String globalProperties) -> {
@@ -92,7 +92,7 @@ public class SaveProperties extends HesperidesScenario implements En {
         When("^I try to save a property declared twice with the same name but different values$", () -> {
             deployedModuleBuilder.withValuedProperty("property-a", "foo");
             deployedModuleBuilder.withValuedProperty("property-a", "bar");
-            saveValuedProperties("should-fail");
+            saveValuedProperties("should-fail", deployedModuleBuilder);
         });
     }
 
@@ -113,10 +113,14 @@ public class SaveProperties extends HesperidesScenario implements En {
     }
 
     void saveValuedProperties() {
-        saveValuedProperties(null);
+        saveValuedProperties(null, deployedModuleBuilder);
     }
 
-    private void saveValuedProperties(String tryTo) {
+    void saveValuedProperties(DeployedModuleBuilder moduleBuilder) {
+        saveValuedProperties(null, moduleBuilder);
+    }
+
+    private void saveValuedProperties(String tryTo, DeployedModuleBuilder deployedModuleBuilder) {
         platformClient.saveProperties(platformBuilder.buildInput(), deployedModuleBuilder.buildProperties(), deployedModuleBuilder.buildPropertiesPath(), tryTo);
         if (isEmpty(tryTo)) {
             platformBuilder.updateDeployedModuleBuilder(deployedModuleBuilder);

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/UpdatePlatforms.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/UpdatePlatforms.java
@@ -167,15 +167,19 @@ public class UpdatePlatforms extends HesperidesScenario implements En {
 
     public UpdatePlatforms() {
 
-        Given("^the platform(?: \"([^\"]+)\")? has these (valued|global|instance|iterable)? properties$", (
-                String platformName, String valuedGlobalInstanceOrIterableProperties, DataTable data) -> {
+        Given("^(?:the module \"([^\"]+)\" of )?the platform(?: \"([^\"]+)\")? has these (valued|global|instance|iterable)? properties$", (
+                String moduleName, String platformName, String propertiesNature, DataTable data) -> {
 
             if (isNotEmpty(platformName)) {
                 // On s'assure que le platformBuilder "actif" correspond bien à la plateforme explicitement nommée
                 assertEquals(platformName, platformBuilder.getPlatformName());
             }
 
-            switch (valuedGlobalInstanceOrIterableProperties) {
+            final DeployedModuleBuilder deployedModuleBuilder = isNotEmpty(moduleName)
+                    ? platformBuilder.findDeployedModuleBuilderByName(moduleName)
+                    : this.deployedModuleBuilder;
+
+            switch (propertiesNature) {
                 case "global":
                     platformBuilder.setGlobalProperties(data.asList(ValuedPropertyIO.class));
                     saveProperties.saveGlobalProperties();
@@ -188,14 +192,14 @@ public class UpdatePlatforms extends HesperidesScenario implements En {
                     break;
                 case "iterable":
                     deployedModuleBuilder.setIterableProperties(dataTableToIterableProperties(data));
-                    saveProperties.saveValuedProperties();
+                    saveProperties.saveValuedProperties(deployedModuleBuilder);
 
                     break;
                 default:
                     deployedModuleBuilder.clearValuedProperties();
                     List<ValuedPropertyIO> valuedProperties = data.asList(ValuedPropertyIO.class);
                     valuedProperties.forEach(property -> deployedModuleBuilder.withValuedProperty(property.getName(), property.getValue().replace("&nbsp;", " ")));
-                    saveProperties.saveValuedProperties();
+                    saveProperties.saveValuedProperties(deployedModuleBuilder);
                     break;
             }
         });

--- a/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/UpdatePlatforms.java
+++ b/tests/bdd/src/main/java/org/hesperides/test/bdd/platforms/scenarios/UpdatePlatforms.java
@@ -167,7 +167,7 @@ public class UpdatePlatforms extends HesperidesScenario implements En {
 
     public UpdatePlatforms() {
 
-        Given("^(?:the module \"([^\"]+)\" of )?the platform(?: \"([^\"]+)\")? has these (valued|global|instance|iterable)? properties$", (
+        Given("^(?:the module \"([^\"]+)\"|the platform(?: \"([^\"]+)\")?) has these (valued|global|instance|iterable)? properties$", (
                 String moduleName, String platformName, String propertiesNature, DataTable data) -> {
 
             if (isNotEmpty(platformName)) {
@@ -175,6 +175,7 @@ public class UpdatePlatforms extends HesperidesScenario implements En {
                 assertEquals(platformName, platformBuilder.getPlatformName());
             }
 
+            // possibilité de surcharger la variable membre dans le cas où c'est un module précis qui nous intéresse
             final DeployedModuleBuilder deployedModuleBuilder = isNotEmpty(moduleName)
                     ? platformBuilder.findDeployedModuleBuilderByName(moduleName)
                     : this.deployedModuleBuilder;

--- a/tests/bdd/src/test/resources/platforms/properties/purge-properties.feature
+++ b/tests/bdd/src/test/resources/platforms/properties/purge-properties.feature
@@ -1,0 +1,65 @@
+Feature: Get rid of unneeded values
+
+  Background:
+    Given an authenticated user
+
+  #issue-803
+  Scenario: clean all platforms
+    Given an existing module named "loh" with this template content
+      """
+      {{ a_property }}
+      {{ b_property }}
+      """
+    And an existing module named "behold" with this template content
+      """
+      {{ c_property }}
+      """
+    And an existing platform with those modules
+    And the module "loh" of the platform has these valued properties
+      | name       | value        |
+      | a_property | a-value      |
+      | awwwww     | right        |
+      | b_property | other-value  |
+      | c_property | misplaced    |
+    And the module "behold" of the platform has these valued properties
+      | name       | value        |
+      | c_property | something    |
+      | d_property | barrel-roll  |
+      | foo        | bar          |
+    When I purge unneeded properties
+    Then module "loh" contains only the following properties
+      | a_property |
+      | b_property |
+    And module "behold" contains only the following properties
+      | c_property |
+
+  Scenario: clean specific path
+    Given an existing module named "shall_pass" with this template content
+      """
+      {{ a_property }}
+      {{ b_property }}
+      """
+    And an existing module named "Istari" with this template content
+      """
+      {{ c_property }}
+      """
+    And an existing platform with those modules
+    And the module "shall_pass" of the platform has these valued properties
+      | name       | value        |
+      | a_property | a-value      |
+      | b_property | other-value  |
+      | c_property | misplaced    |
+    And the module "Istari" of the platform has these valued properties
+      | name       | value        |
+      | c_property | something    |
+      | d_property | barrel-roll  |
+      | foo        | bar          |
+    When I purge unneeded properties on path "#ABC#DEF#shall_pass#1.0#WORKINGCOPY"
+    Then module "shall_pass" contains only the following properties
+      | a_property |
+      | b_property |
+    And module "Istari" contains only the following properties
+      | c_property |
+      | d_property |
+      | foo        |
+

--- a/tests/bdd/src/test/resources/platforms/properties/purge-properties.feature
+++ b/tests/bdd/src/test/resources/platforms/properties/purge-properties.feature
@@ -74,3 +74,31 @@ Feature: Get rid of unneeded values
     And an existing platform with this module and valued properties and global properties
     When I try to purge unneeded global properties of this platform
     Then the request is rejected with a bad request error
+
+  Scenario: do not clean "indirect" values
+    Given an existing module named "basic" with this template content
+      """
+      {{ a_property }}
+      {{ b_property }}
+      {{ c_property }}
+      """
+    And an existing platform with this module and an instance
+    And the module "basic" has these valued properties
+      | name       | value                  |
+      | a_property | {{ind1}}//url/{{ind3}} |
+      | b_property | {{ind2}}               |
+      | ind1       | http:                  |
+      | ind2       | {{ind1}}//other_url    |
+      | ind3       | service_path           |
+      | ind4       | www.perdu.com          |
+    And the platform has these instance properties
+      | name       | value                  |
+      | c_property | {{ind1}}//{{ind4}}     |
+    When I purge unneeded properties of this platform
+    Then the module "basic" still contains all the following properties
+      | a_property |
+      | b_property |
+      | ind1       |
+      | ind2       |
+      | ind3       |
+      | ind4       |

--- a/tests/bdd/src/test/resources/platforms/properties/purge-properties.feature
+++ b/tests/bdd/src/test/resources/platforms/properties/purge-properties.feature
@@ -1,10 +1,10 @@
+#issue-803
 Feature: Get rid of unneeded values
 
   Background:
     Given an authenticated user
 
-  #issue-803
-  Scenario: clean all platforms
+  Scenario: clean all modules in platform
     Given an existing module named "loh" with this template content
       """
       {{ a_property }}
@@ -15,25 +15,25 @@ Feature: Get rid of unneeded values
       {{ c_property }}
       """
     And an existing platform with those modules
-    And the module "loh" of the platform has these valued properties
+    And the module "loh" has these valued properties
       | name       | value        |
       | a_property | a-value      |
       | awwwww     | right        |
       | b_property | other-value  |
       | c_property | misplaced    |
-    And the module "behold" of the platform has these valued properties
+    And the module "behold" has these valued properties
       | name       | value        |
       | c_property | something    |
       | d_property | barrel-roll  |
       | foo        | bar          |
-    When I purge unneeded properties
-    Then module "loh" contains only the following properties
+    When I purge unneeded properties of this platform
+    Then the module "loh" contains only the following properties
       | a_property |
       | b_property |
-    And module "behold" contains only the following properties
+    And the module "behold" contains only the following properties
       | c_property |
 
-  Scenario: clean specific path
+  Scenario: clean specific module
     Given an existing module named "shall_pass" with this template content
       """
       {{ a_property }}
@@ -44,22 +44,33 @@ Feature: Get rid of unneeded values
       {{ c_property }}
       """
     And an existing platform with those modules
-    And the module "shall_pass" of the platform has these valued properties
+    And the module "shall_pass" has these valued properties
       | name       | value        |
       | a_property | a-value      |
       | b_property | other-value  |
       | c_property | misplaced    |
-    And the module "Istari" of the platform has these valued properties
+    And the module "Istari" has these valued properties
       | name       | value        |
       | c_property | something    |
       | d_property | barrel-roll  |
       | foo        | bar          |
-    When I purge unneeded properties on path "#ABC#DEF#shall_pass#1.0#WORKINGCOPY"
-    Then module "shall_pass" contains only the following properties
+    When I purge unneeded properties of module "shall_pass"
+    Then the module "shall_pass" contains only the following properties
       | a_property |
       | b_property |
-    And module "Istari" contains only the following properties
+    And the module "Istari" still contains all the following properties
       | c_property |
       | d_property |
       | foo        |
 
+  Scenario: clean unknown module
+    Given an existing module named "bob"
+    And an existing platform with this module and valued properties
+    When I try to purge unneeded properties of unknown module "not_bob"
+    Then the resource is not found
+
+  Scenario: clean global properties
+    Given an existing module
+    And an existing platform with this module and valued properties and global properties
+    When I try to purge unneeded global properties of this platform
+    Then the request is rejected with a bad request error


### PR DESCRIPTION
## Overview
### TL;DR
Make it so that properties values no longer needed by their template (a.k.a. `module`) are purged for a whole platform.

### Long version
closes #803 

Furthermore, the optional `properties_path` request argument allows to use this new service to replace what the front app is doing now.

## Review
:eyes: @thomaslhostis 