### PR TITLE
Fix runtime OpenJDK version in Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,6 @@ stages:
 jobs:
   include:
     - stage: build
-      env: BUILD WITHOUT TEST
-      install: echo Not performing default install step
-      script: mvn clean package -Dmaven.test.skip=true --settings ./.travis/deploy-settings.xml
-    - stage: build
       env: BUILD DOCKER IMAGE
       install: echo Not performing default install step
       script: |
@@ -38,6 +34,8 @@ jobs:
             --build-arg GIT_BRANCH=$TRAVIS_BRANCH \
             --build-arg GIT_COMMIT=$TRAVIS_COMMIT \
             --build-arg GIT_COMMIT_MSG="$TRAVIS_COMMIT_MESSAGE" .
+        # We validate that the image built can start without any error:
+        docker run --rm -e SPRING_PROFILES_ACTIVE=noldap,fake_mongo -e EXIT_AFTER_INIT=true hesperides/hesperides:$TRAVIS_COMMIT
         docker save --output hesperides-docker-image.tar hesperides/hesperides:$TRAVIS_COMMIT
       workspaces:
         create:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,13 @@ COPY pom.xml .
 RUN mvn clean package -Dmaven.test.skip=true -Dmaven.javadoc.skip=true
 
 
-FROM openjdk:8-jre-alpine
+FROM openjdk:11-jre-slim
 
-RUN apk add curl mongodb
-# We only need the MongoDB shell:
-RUN rm /etc/init.d/mongo* /etc/conf.d/mongo* /usr/bin/mongod /usr/bin/mongos /etc/logrotate.d/mongodb /usr/bin/install_compass
+# Installing curl & MongoDB shell:
+RUN apt-get update -y && apt-get install -y curl gnupg
+RUN curl -s https://www.mongodb.org/static/pgp/server-4.2.asc | apt-key add -
+RUN echo "deb http://repo.mongodb.org/apt/debian buster/mongodb-org/4.2 main" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list
+RUN apt-get update -y && apt-get install -y mongodb-org-shell
 
 COPY --from=0 /usr/local/src/bootstrap/target/hesperides-*.jar hesperides.jar
 COPY mongo_create_collections.js /
@@ -38,10 +40,11 @@ EXPOSE 8080
 
 HEALTHCHECK --interval=5s --timeout=3s --retries=3 CMD curl --fail http://localhost:8080/rest/manage/health || exit 1
 
+RUN cp /usr/local/openjdk-*/bin/java /usr/local/bin/java
 # -XX:+ExitOnOutOfMemoryError : an OutOfMemoryError will often leave the JVM in an inconsistent state. Terminating the JVM will allow it to be restarted by an external process manager
 # -XX:+HeapDumpOnOutOfMemoryError : get a heap dump when the app crashes
 # -XX:-OmitStackTraceInFastThrow : avoid missing stacktraces cf. https://plumbr.io/blog/java/on-a-quest-for-missing-stacktraces
-CMD /usr/bin/java $JAVA_OPTS \
+CMD /usr/local/bin/java $JAVA_OPTS \
      -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:-OmitStackTraceInFastThrow \
      -Xms2g -Xmx4g \
      -jar /hesperides.jar

--- a/bootstrap/src/main/java/org/hesperides/HesperidesSpringApplication.java
+++ b/bootstrap/src/main/java/org/hesperides/HesperidesSpringApplication.java
@@ -1,15 +1,25 @@
 package org.hesperides;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.util.Arrays;
 
 @SpringBootApplication
 @EnableCaching
+@Slf4j
 public class HesperidesSpringApplication {
 
     public static void main(String[] args) {
+        log.info("Program arguments: " + Arrays.toString(args));
         System.setProperty("org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH", "true");
-        SpringApplication.run(HesperidesSpringApplication.class, args);
+        ConfigurableApplicationContext ctx = SpringApplication.run(HesperidesSpringApplication.class, args);
+        if (System.getenv("EXIT_AFTER_INIT") != null) {
+            log.info("Immediately stopping the app:");
+            System.exit(SpringApplication.exit(ctx, () -> 0));
+        }
     }
 }

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -o pipefail -o errexit -o nounset
 
 if [ -z "${MONGO_URI:-}" ]; then


### PR DESCRIPTION
This fix also ensures that we test the generated Docker image as part of our CI pipeline