### PR TITLE
Deprecated: /events/{stream_name} & /events/platforms/{application_name}/{platform_name} ressources

### DIFF
--- a/core/application/src/main/java/org/hesperides/core/application/events/EventUseCases.java
+++ b/core/application/src/main/java/org/hesperides/core/application/events/EventUseCases.java
@@ -82,6 +82,12 @@ public class EventUseCases {
     }
 
     public List<EventView> getEvents(TemplateContainer.Key key, Integer page, Integer size) {
+
+        List<EventView> eventViewList = moduleQueries.getOptionalModuleId(key)
+                .map(moduleId -> eventQueries.getEvents(moduleId, page, size))
+                .orElseGet(Collections::emptyList);
+
+
         return moduleQueries.getOptionalModuleId(key)
                 .map(moduleId -> eventQueries.getEvents(moduleId, page, size))
                 .orElseGet(Collections::emptyList);

--- a/core/domain/src/main/java/org/hesperides/core/domain/events/queries/EventQueries.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/events/queries/EventQueries.java
@@ -3,8 +3,10 @@ package org.hesperides.core.domain.events.queries;
 import org.axonframework.queryhandling.QueryGateway;
 import org.hesperides.commons.axon.AxonQueries;
 import org.hesperides.core.domain.events.GenericEventsByStreamQuery;
+import org.hesperides.core.domain.security.UserEvent;
 import org.springframework.stereotype.Component;
 
+import java.lang.reflect.Array;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,7 +20,12 @@ public class EventQueries extends AxonQueries {
     }
 
     public List<EventView> getEvents(String aggregateId, Integer page, Integer size) {
-        List<EventView> events = querySyncList(new GenericEventsByStreamQuery(aggregateId), EventView.class);
+        List<EventView> events = querySyncList(new GenericEventsByStreamQuery(aggregateId, new Class[0]), EventView.class);
+        return ordinateAndPaginateAccordingSize(events, page, size);
+    }
+
+    public List<EventView> getEventsWithType(String aggregateId, Class[] filterType, Integer page, Integer size) {
+        List<EventView> events = querySyncList(new GenericEventsByStreamQuery(aggregateId, filterType), EventView.class);
         return ordinateAndPaginateAccordingSize(events, page, size);
     }
 

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/events/UpdatedPlatformEventsView.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/views/events/UpdatedPlatformEventsView.java
@@ -1,0 +1,82 @@
+package org.hesperides.core.domain.platforms.queries.views.events;
+
+import lombok.Value;
+import lombok.experimental.NonFinal;
+
+import java.util.List;
+
+@Value
+public class UpdatedPlatformEventsView {
+    Long timestamp;
+    List<UpdatedPlatformEventView> events;
+
+    @Value
+    @NonFinal
+    public abstract class UpdatedPlatformEventView {
+        UpdatedPlatformEventType eventType;
+
+        public UpdatedPlatformEventView(UpdatedPlatformEventType updatedPlatformEventType) {
+            this.eventType = updatedPlatformEventType;
+        }
+    }
+
+    @Value
+    public class PlatformVersionUpdatedEventView extends UpdatedPlatformEventView {
+        String oldVersion;
+        String newVersion;
+
+        public PlatformVersionUpdatedEventView(UpdatedPlatformEventType updatedPlatformEventType,
+                                               String oldVersion,
+                                               String newVersion) {
+            super(updatedPlatformEventType);
+            this.oldVersion = oldVersion;
+            this.newVersion = newVersion;
+        }
+    }
+
+    @Value
+    public class DeployedModuleVersionUpdatedEventView extends UpdatedPlatformEventView {
+        String propertiesPath;
+        String oldVersion;
+        String newVersion;
+
+        public DeployedModuleVersionUpdatedEventView(UpdatedPlatformEventType updatedPlatformEventType,
+                                            String propertiesPath,
+                                            String oldVersion,
+                                            String newVersion) {
+            super(updatedPlatformEventType);
+            this.propertiesPath = propertiesPath;
+            this.oldVersion = oldVersion;
+            this.newVersion = newVersion;
+        }
+    }
+
+    @Value
+    public class DeployedModuleAddedEventView extends UpdatedPlatformEventView {
+        String propertiesPath;
+
+        public DeployedModuleAddedEventView(UpdatedPlatformEventType updatedPlatformEventType,
+                                            String propertiesPath) {
+            super(updatedPlatformEventType);
+            this.propertiesPath = propertiesPath;
+        }
+    }
+
+    @Value
+    public class DeployedModuleRemovedEventView extends UpdatedPlatformEventView {
+        String propertiesPath;
+
+        public DeployedModuleRemovedEventView(UpdatedPlatformEventType updatedPlatformEventType,
+                                              String propertiesPath) {
+            super(updatedPlatformEventType);
+            this.propertiesPath = propertiesPath;
+        }
+    }
+
+    public enum UpdatedPlatformEventType {
+        PLATFORM_VERSION_UPDATED,
+        DEPLOYED_MODULE_VERSION_UPDATED,
+        DEPLOYED_MODULE_ADDED,
+        DEPLOYED_MODULE_REMOVED;
+    }
+}

--- a/core/domain/src/main/kotlin/org/hesperides/core/domain/events/Events.kt
+++ b/core/domain/src/main/kotlin/org/hesperides/core/domain/events/Events.kt
@@ -1,4 +1,6 @@
 package org.hesperides.core.domain.events
 
-data class GenericEventsByStreamQuery(val aggregateIdentifier: String)
+import org.hesperides.core.domain.security.UserEvent
+
+data class GenericEventsByStreamQuery(val aggregateIdentifier: String, val typeFilter: Array<Class<UserEvent>>)
 data class CleanAggregateEventsQuery(val aggregateIdentifier: String)

--- a/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/events/MongoAxonEventRepository.java
+++ b/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/events/MongoAxonEventRepository.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,6 +37,8 @@ public class MongoAxonEventRepository implements EventRepository {
         return eventStorageEngine.readEvents(query.getAggregateIdentifier())
                 .asStream()
                 .map(EventView::new)
+                .filter(eventView -> query.getTypeFilter().length == 0
+                        || Arrays.stream(query.getTypeFilter()).anyMatch(userEventClass -> eventView.getData().getClass().equals(userEventClass)))
                 .collect(Collectors.toList());
     }
 

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/EventsController.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/EventsController.java
@@ -29,6 +29,7 @@ public class EventsController extends AbstractController {
         this.eventUseCases = eventUseCases;
     }
 
+    @Deprecated
     @ApiOperation("Get the events list from a legacy stream name of platform or module")
     @GetMapping("/{stream_name:.+}")
     public ResponseEntity<List<EventOutput>> getEvents(@PathVariable("stream_name") final String streamName,
@@ -39,7 +40,11 @@ public class EventsController extends AbstractController {
                 .stream()
                 .map(EventOutput::new)
                 .collect(Collectors.toList());
-        return ResponseEntity.ok().body(events);
+        return ResponseEntity.ok()
+                .header("Deprecation", "version=\"2021-01-01\"")
+                .header("Sunset", " Jan  15 00:00:00 CEST 2020")
+                .header("Link", "/applications/{application_name}/platforms/{platform_name}/properties/events")
+                .body(events);
     }
 
     @ApiOperation("Get the events list of a module")
@@ -60,6 +65,7 @@ public class EventsController extends AbstractController {
         return ResponseEntity.ok().body(events);
     }
 
+    @Deprecated
     @ApiOperation("Get the events list of a platform")
     @GetMapping("/platforms/{application_name}/{platform_name}")
     public ResponseEntity<List<EventOutput>> getPlatformEvents(@PathVariable("application_name") final String applicationName,
@@ -74,7 +80,11 @@ public class EventsController extends AbstractController {
                 .stream()
                 .map(EventOutput::new)
                 .collect(Collectors.toList());
-        return ResponseEntity.ok().body(events);
+        return ResponseEntity.ok()
+                .header("Deprecation", "version=\"2021-01-01\"")
+                .header("Sunset", " Jan  15 00:00:00 CEST 2020")
+                .header("Link", String.format("/applications/%s/platforms/%s/events", applicationName, platformName))
+                .body(events);
     }
 
 }

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/PlatformsController.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/PlatformsController.java
@@ -6,13 +6,16 @@ import io.swagger.annotations.ApiParam;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hesperides.core.application.platforms.PlatformUseCases;
+import org.hesperides.core.domain.events.queries.EventView;
 import org.hesperides.core.domain.modules.entities.Module;
 import org.hesperides.core.domain.platforms.entities.Platform;
 import org.hesperides.core.domain.platforms.queries.views.ModulePlatformView;
 import org.hesperides.core.domain.platforms.queries.views.PlatformView;
 import org.hesperides.core.domain.platforms.queries.views.SearchPlatformResultView;
+import org.hesperides.core.domain.security.UserEvent;
 import org.hesperides.core.domain.security.entities.User;
 import org.hesperides.core.domain.templatecontainers.entities.TemplateContainer;
+import org.hesperides.core.presentation.io.events.EventOutput;
 import org.hesperides.core.presentation.io.platforms.ModulePlatformsOutput;
 import org.hesperides.core.presentation.io.platforms.PlatformIO;
 import org.hesperides.core.presentation.io.platforms.SearchResultOutput;
@@ -97,6 +100,17 @@ public class PlatformsController extends AbstractController {
 
         PlatformIO platformOutput = new PlatformIO(platformView);
         return ResponseEntity.ok(platformOutput);
+    }
+
+    @ApiOperation("Retrieve a platform events")
+    @GetMapping("/{application_name}/platforms/{platform_name:.+}/events")
+    public ResponseEntity<List<EventOutput>> getPlatformEvents(@PathVariable("application_name") final String applicationName,
+                                                       @PathVariable("platform_name") final String platformName) {
+
+        Platform.Key platformKey = new Platform.Key(applicationName, platformName);
+        List<EventView> eventView = platformUseCases.getPlatformEvents(platformKey);
+
+        return ResponseEntity.ok(EventOutput.fromEventViews(eventView));
     }
 
     @ApiOperation("Update a platform")

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/io/events/EventOutput.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/io/events/EventOutput.java
@@ -5,7 +5,16 @@ import org.hesperides.core.domain.events.queries.EventView;
 import org.hesperides.core.domain.modules.ModuleCreatedEvent;
 import org.hesperides.core.domain.modules.TemplateCreatedEvent;
 import org.hesperides.core.domain.modules.TemplateUpdatedEvent;
+import org.hesperides.core.domain.platforms.PlatformCreatedEvent;
+import org.hesperides.core.domain.platforms.PlatformUpdatedEvent;
 import org.hesperides.core.domain.security.UserEvent;
+import org.hesperides.core.domain.technos.queries.TechnoView;
+import org.hesperides.core.presentation.io.TechnoIO;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 @Value
@@ -23,6 +32,14 @@ public class EventOutput {
         this.data = getEventData(view.getData());
     }
 
+    public static List<EventOutput> fromEventViews(List<EventView> eventViews) {
+        return Optional.ofNullable(eventViews)
+                .orElseGet(Collections::emptyList)
+                .stream()
+                .map(EventOutput::new)
+                .collect(Collectors.toList());
+    }
+
     /*
      * For legacy retro-compatibility, look for usage of event.data in: https://github.com/voyages-sncf-technologies/hesperides-gui/tree/master/src/app/event/directives
      */
@@ -35,6 +52,12 @@ public class EventOutput {
         }
         if (userEvent instanceof TemplateUpdatedEvent) {
             return new TemplateUpdatedEventIO((TemplateUpdatedEvent) userEvent);
+        }
+        if (userEvent instanceof PlatformCreatedEvent) {
+            return new PlatformCreatedEventIO((PlatformCreatedEvent) userEvent);
+        }
+        if (userEvent instanceof PlatformUpdatedEvent) {
+            return new PlatformUpdatedEventIO((PlatformUpdatedEvent) userEvent);
         }
         // For TemplateDeletedEvent, only field used by legacy front is .templateName, so we pass through the event
         // For many other events (ModuleTechnosUpdatedEvent, techno events...) legacy front was totally bogus and used .platform.platform_name...

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/io/events/PlatformCreatedEventIO.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/io/events/PlatformCreatedEventIO.java
@@ -1,0 +1,17 @@
+package org.hesperides.core.presentation.io.events;
+
+import lombok.Value;
+import org.hesperides.core.domain.platforms.PlatformCreatedEvent;
+import org.hesperides.core.domain.platforms.entities.Platform;
+
+@Value
+public class PlatformCreatedEventIO {
+    private Platform platformCreated;
+    private String user;
+
+    public PlatformCreatedEventIO(PlatformCreatedEvent platformCreatedEvent) {
+        this.platformCreated = platformCreatedEvent.getPlatform();
+        this.user = platformCreatedEvent.getUser();
+
+    }
+}

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/io/events/PlatformUpdatedEventIO.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/io/events/PlatformUpdatedEventIO.java
@@ -1,0 +1,14 @@
+package org.hesperides.core.presentation.io.events;
+
+import lombok.Value;
+import org.hesperides.core.domain.platforms.PlatformUpdatedEvent;
+import org.hesperides.core.domain.platforms.entities.Platform;
+
+@Value
+public class PlatformUpdatedEventIO {
+    private Platform platformUpdated;
+
+    public PlatformUpdatedEventIO(PlatformUpdatedEvent platformUpdatedEvent) {
+        this.platformUpdated = platformUpdatedEvent.getPlatform();
+    }
+}

--- a/tests/perfs/dependency-reduced-pom.xml
+++ b/tests/perfs/dependency-reduced-pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.16.20</version>
+      <version>1.18.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Juste la partie deprecated pour le moment

J'ai un doute sur 2 choses:
* la date de la fin du mise en service des ressources
* la nouvelle uri du service stream, c'est remplacé par quoi du coup ?