### PR TITLE
Fix #832: Impossible de purger les propriétés inutilisées d'un module dont le `propertiesVersionId` est à `null`

### DIFF
--- a/core/application/src/main/java/org/hesperides/core/application/platforms/PlatformUseCases.java
+++ b/core/application/src/main/java/org/hesperides/core/application/platforms/PlatformUseCases.java
@@ -20,6 +20,7 @@ import org.hesperides.core.domain.platforms.entities.properties.diff.PropertiesD
 import org.hesperides.core.domain.platforms.entities.properties.diff.PropertiesDiff.ComparisonMode;
 import org.hesperides.core.domain.platforms.entities.properties.visitors.PropertyVisitorsSequence;
 import org.hesperides.core.domain.platforms.exceptions.ApplicationNotFoundException;
+import org.hesperides.core.domain.platforms.exceptions.DeployedModuleNotFoundException;
 import org.hesperides.core.domain.platforms.exceptions.DuplicatePlatformException;
 import org.hesperides.core.domain.platforms.exceptions.PlatformNotFoundException;
 import org.hesperides.core.domain.platforms.queries.PlatformQueries;
@@ -263,32 +264,36 @@ public class PlatformUseCases {
         return platformQueries.searchPlatforms(applicationName, platformName);
     }
 
-    public Long getPropertiesVersionId(final Platform.Key platformKey, final String propertiesPath) {
-        return getPropertiesVersionId(platformKey, propertiesPath, null);
-    }
-
-    public Long getPropertiesVersionId(final Platform.Key platformKey, final String propertiesPath, final Long timestamp) {
-
-        Optional<Long> propertiesVersionId = Optional.empty();
+    public static Long getPropertiesVersionId(PlatformView platform, String propertiesPath) {
+        Long propertiesVersionId;
 
         if (Platform.isGlobalPropertiesPath(propertiesPath)) {
-            propertiesVersionId = platformQueries.getGlobalPropertiesVersionId(platformKey);
-        } else if (StringUtils.isNotEmpty(propertiesPath)) {
-            final String platformId = platformQueries.getOptionalPlatformId(platformKey).orElseThrow(() -> new PlatformNotFoundException(platformKey));
-            propertiesVersionId = Optional.ofNullable(platformQueries.getPropertiesVersionId(platformId, propertiesPath, timestamp));
+            propertiesVersionId = platform.getGlobalPropertiesVersionId();
+        } else {
+            propertiesVersionId = platform.getActiveDeployedModules()
+                    .filter(deployedModule -> deployedModule.getPropertiesPath().equals(propertiesPath))
+                    .findFirst()
+                    .orElseThrow(() -> new DeployedModuleNotFoundException(platform.getPlatformKey(), propertiesPath))
+                    .getPropertiesVersionId();
         }
-        return propertiesVersionId.orElse(DeployedModule.INIT_PROPERTIES_VERSION_ID);
+        return Optional.ofNullable(propertiesVersionId)
+                .orElse(DeployedModule.INIT_PROPERTIES_VERSION_ID);
     }
 
-    public PropertiesDiff getPropertiesDiff(final Platform.Key fromPlatformKey,
-                                            final String fromPropertiesPath,
-                                            final String fromInstanceName,
-                                            final Platform.Key toPlatformKey,
-                                            final String toPropertiesPath,
-                                            final String toInstanceName,
-                                            @Nullable final Long timestamp,
-                                            final ComparisonMode comparisonMode,
-                                            final User user) {
+    public Long getPropertiesVersionId(Platform.Key platformKey, String propertiesPath, Long timestamp) {
+        PlatformView platform = timestamp != null ? getPlatformAtPointInTime(platformKey, timestamp) : getPlatform(platformKey);
+        return getPropertiesVersionId(platform, propertiesPath);
+    }
+
+    public PropertiesDiff getPropertiesDiff(Platform.Key fromPlatformKey,
+                                            String fromPropertiesPath,
+                                            String fromInstanceName,
+                                            Platform.Key toPlatformKey,
+                                            String toPropertiesPath,
+                                            String toInstanceName,
+                                            @Nullable Long timestamp,
+                                            ComparisonMode comparisonMode,
+                                            User user) {
 
         PlatformView fromPlatform = getPlatform(fromPlatformKey);
         PlatformView toPlatform = timestamp != null ? getPlatformAtPointInTime(toPlatformKey, timestamp) : getPlatform(toPlatformKey);
@@ -393,7 +398,7 @@ public class PlatformUseCases {
         return propertyVisitorsSequence.getPropertiesWithDetails();
     }
 
-    public List<AbstractValuedPropertyView> getValuedProperties(final Platform.Key platformKey, final String propertiesPath, final Long timestamp, final User user) {
+    public List<AbstractValuedPropertyView> getValuedProperties(Platform.Key platformKey, String propertiesPath, Long timestamp, User user) {
         List<AbstractValuedPropertyView> properties = new ArrayList<>();
 
         PlatformView platform = timestamp != null ? getPlatformAtPointInTime(platformKey, timestamp) : getPlatform(platformKey);
@@ -401,7 +406,7 @@ public class PlatformUseCases {
         if (Platform.isGlobalPropertiesPath(propertiesPath)) {
             properties.addAll(platform.getGlobalProperties());
         } else if (StringUtils.isNotEmpty(propertiesPath)) {
-            final Module.Key moduleKey = Module.Key.fromPropertiesPath(propertiesPath);
+            Module.Key moduleKey = Module.Key.fromPropertiesPath(propertiesPath);
             // Note: on devrait passer le timestamp aux 2 appels ci-dessous, cf. issue #724
             List<AbstractPropertyView> modulePropertiesModel = moduleQueries.getPropertiesModel(moduleKey);
 
@@ -421,7 +426,7 @@ public class PlatformUseCases {
         return properties;
     }
 
-    public Map<String, Set<GlobalPropertyUsageView>> getGlobalPropertiesUsage(final Platform.Key platformKey) {
+    public Map<String, Set<GlobalPropertyUsageView>> getGlobalPropertiesUsage(Platform.Key platformKey) {
         PlatformView platform = platformQueries.getOptionalPlatform(platformKey).orElseThrow(() -> new PlatformNotFoundException(platformKey));
 
         // On ne tient compte que des modules utilisés dans la platforme (pas des modules sauvegardés)
@@ -441,20 +446,20 @@ public class PlatformUseCases {
                         GlobalPropertyUsageView.getGlobalPropertyUsage(globalPropertyName, deployedModules, modulesProperties)));
     }
 
-    public List<String> getInstancesModel(final Platform.Key platformKey, final String propertiesPath) {
+    public List<String> getInstancesModel(Platform.Key platformKey, String propertiesPath) {
         if (!platformQueries.platformExists(platformKey)) {
             throw new PlatformNotFoundException(platformKey);
         }
         return platformQueries.getInstancesModel(platformKey, propertiesPath);
     }
 
-    public List<AbstractValuedPropertyView> saveProperties(final Platform.Key platformKey,
-                                                           final String propertiesPath,
-                                                           final Long platformVersionId,
-                                                           final List<AbstractValuedProperty> abstractValuedProperties,
-                                                           final Long propertiesVersionId,
-                                                           final String userComment,
-                                                           final User user) {
+    public List<AbstractValuedPropertyView> saveProperties(Platform.Key platformKey,
+                                                           String propertiesPath,
+                                                           Long platformVersionId,
+                                                           List<AbstractValuedProperty> abstractValuedProperties,
+                                                           Long propertiesVersionId,
+                                                           String userComment,
+                                                           User user) {
         PlatformView platform = getPlatform(platformKey);
         if (platform.isProductionPlatform() && !user.hasProductionRoleForApplication(platformKey.getApplicationName())) {
             throw new ForbiddenOperationException("Setting properties of a production platform is reserved to production role");
@@ -464,7 +469,7 @@ public class PlatformUseCases {
             throw new IllegalArgumentException("Saving properties with duplicate keys is forbidden");
         }
 
-        Long expectedPropertiesVersionId = getPropertiesVersionId(platformKey, propertiesPath);
+        Long expectedPropertiesVersionId = getPropertiesVersionId(platform, propertiesPath);
 
         if (Platform.isGlobalPropertiesPath(propertiesPath)) {
             List<ValuedProperty> valuedProperties = AbstractValuedProperty.filterAbstractValuedPropertyWithType(abstractValuedProperties, ValuedProperty.class);
@@ -474,7 +479,7 @@ public class PlatformUseCases {
             }
             platformCommands.savePlatformProperties(platform.getId(), platformVersionId, propertiesVersionId, expectedPropertiesVersionId, valuedProperties, user);
         } else {
-            final Module.Key moduleKey = Module.Key.fromPropertiesPath(propertiesPath);
+            Module.Key moduleKey = Module.Key.fromPropertiesPath(propertiesPath);
             if (!moduleQueries.moduleExists(moduleKey)) {
                 throw new ModuleNotFoundException(moduleKey);
             }
@@ -510,7 +515,7 @@ public class PlatformUseCases {
         allSimpleProperties.forEach(moduleProperty -> moduleProperty.validateRequiredAndPatternProperties(allValuedProperties));
     }
 
-    public PlatformView restoreDeletedPlatform(final Platform.Key platformKey, final User user) {
+    public PlatformView restoreDeletedPlatform(Platform.Key platformKey, User user) {
         if (platformQueries.platformExists(platformKey)) {
             throw new IllegalArgumentException("Cannot restore an existing platform");
         }
@@ -540,7 +545,7 @@ public class PlatformUseCases {
     }
 
     public void purgeUnusedProperties(Platform.Key platformKey, String propertiesPath, User user) {
-        final PlatformView platform = getPlatform(platformKey);
+        PlatformView platform = getPlatform(platformKey);
         if (platform.isProductionPlatform() && !user.hasProductionRoleForApplication(platformKey.getApplicationName())) {
             throw new ForbiddenOperationException("Cleaning properties of a production platform is reserved to production role");
         }
@@ -548,19 +553,19 @@ public class PlatformUseCases {
             throw new IllegalArgumentException("Cleaning only works on module properties (not global ones!)");
         }
 
-        final DeployedModuleView deployedModule = platform.getDeployedModule(propertiesPath);
-        final Module.Key moduleKey = Module.Key.fromPropertiesPath(propertiesPath);
+        DeployedModuleView deployedModule = platform.getDeployedModule(propertiesPath);
+        Module.Key moduleKey = Module.Key.fromPropertiesPath(propertiesPath);
 
-        final List<AbstractPropertyView> propertiesModel = moduleQueries.getPropertiesModel(moduleKey);
-        final List<AbstractValuedPropertyView> baseValues = deployedModule.getValuedProperties();
-        final Set<String> referencedProperties = propertyReferenceScanner.findAll(baseValues, deployedModule.getInstances());
+        List<AbstractPropertyView> propertiesModel = moduleQueries.getPropertiesModel(moduleKey);
+        List<AbstractValuedPropertyView> baseValues = deployedModule.getValuedProperties();
+        Set<String> referencedProperties = propertyReferenceScanner.findAll(baseValues, deployedModule.getInstances());
 
         List<AbstractValuedProperty> filteredValuedProperties = excludeUnusedValues(baseValues, propertiesModel, referencedProperties)
                 .map(AbstractValuedPropertyView::toDomainValuedProperty)
                 .map(AbstractValuedProperty.class::cast)
                 .collect(Collectors.toList());
 
-        Long propertiesVersionId = platformQueries.getPropertiesVersionId(platform.getId(), propertiesPath, null);
+        Long propertiesVersionId = getPropertiesVersionId(platform, propertiesPath);
 
         platformCommands.saveModulePropertiesInPlatform(platform.getId(), propertiesPath, platform.getVersionId(),
                 propertiesVersionId, propertiesVersionId, filteredValuedProperties,

--- a/core/application/src/test/java/org/hesperides/core/application/platforms/PlatformUseCasesTest.java
+++ b/core/application/src/test/java/org/hesperides/core/application/platforms/PlatformUseCasesTest.java
@@ -1,0 +1,49 @@
+/*
+ *
+ * This file is part of the Hesperides distribution.
+ * (https://github.com/voyages-sncf-technologies/hesperides)
+ * Copyright (c) 2016 VSCT.
+ *
+ * Hesperides is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, version 3.
+ *
+ * Hesperides is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
+package org.hesperides.core.application.platforms;
+
+import org.hesperides.core.domain.platforms.queries.views.DeployedModuleView;
+import org.hesperides.core.domain.platforms.queries.views.PlatformView;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hesperides.core.application.platforms.PlatformUseCases.getPropertiesVersionId;
+import static org.junit.Assert.assertEquals;
+
+public class PlatformUseCasesTest {
+
+    @Test
+    public void testGetPropertiesVersionId() {
+        PlatformView platformWithoutGlobalPropertiesVersionId = new PlatformView(null, null, null, null, false, null, null, null, null);
+        assertEquals(Long.valueOf(0), getPropertiesVersionId(platformWithoutGlobalPropertiesVersionId, "#"));
+        PlatformView platformWithGlobalPropertiesVersionId = new PlatformView(null, null, null, null, false, null, null, 1L, null);
+        assertEquals(Long.valueOf(1), getPropertiesVersionId(platformWithGlobalPropertiesVersionId, "#"));
+
+        DeployedModuleView deployedModuleWithoutPropertiesVersionId = new DeployedModuleView(1L, null, null, null, false, null, "A", null, null, null);
+        PlatformView platform = new PlatformView(null, null, null, null, false, Collections.singletonList(deployedModuleWithoutPropertiesVersionId), null, null, null);
+        assertEquals(Long.valueOf(0), getPropertiesVersionId(platform, "A"));
+
+        DeployedModuleView deployedModuleWithPropertiesVersionId = new DeployedModuleView(1L, 1L, null, null, false, null, "A", null, null, null);
+        platform = new PlatformView(null, null, null, null, false, Collections.singletonList(deployedModuleWithPropertiesVersionId), null, null, null);
+        assertEquals(Long.valueOf(1), getPropertiesVersionId(platform, "A"));
+    }
+}

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/PlatformProjectionRepository.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/PlatformProjectionRepository.java
@@ -69,12 +69,6 @@ public interface PlatformProjectionRepository {
     List<SearchPlatformResultView> onSearchPlatformsQuery(SearchPlatformsQuery query);
 
     @QueryHandler
-    Long onGetPropertiesVersionIdQuery(GetPropertiesVersionIdQuery query);
-
-    @QueryHandler
-    Optional<Long> onGetGlobalPropertiesVersionIdQuery(GetGlobalPropertiesVersionIdQuery query);
-
-    @QueryHandler
     List<ValuedPropertyView> onGetGlobalPropertiesQuery(GetGlobalPropertiesQuery query);
 
     @QueryHandler

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/PlatformQueries.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/queries/PlatformQueries.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ExecutionException;
 @Component
 public class PlatformQueries extends AxonQueries {
 
-    private QueryGateway queryGateway;
+    private final QueryGateway queryGateway;
 
     protected PlatformQueries(QueryGateway queryGateway) {
         super(queryGateway);
@@ -80,7 +80,7 @@ public class PlatformQueries extends AxonQueries {
         return querySyncOptional(new GetApplicationByNameQuery(applicationName, hidePlatformsModules), ApplicationView.class);
     }
 
-    public List<String> getInstancesModel(final Platform.Key platformKey, final String propertiesPath) {
+    public List<String> getInstancesModel(Platform.Key platformKey, String propertiesPath) {
         return querySyncList(new GetInstancesModelQuery(platformKey, propertiesPath), String.class);
     }
 
@@ -100,15 +100,7 @@ public class PlatformQueries extends AxonQueries {
         return querySyncList(new SearchPlatformsQuery(applicationName, platformName), SearchPlatformResultView.class);
     }
 
-    public Long getPropertiesVersionId(final String platformId, final String propertiesPath, final Long timestamp) {
-        return querySync(new GetPropertiesVersionIdQuery(platformId, propertiesPath, timestamp == null ? -1 : timestamp), Long.class);
-    }
-
-    public Optional<Long> getGlobalPropertiesVersionId(final Platform.Key platformKey) {
-        return querySyncOptional(new GetGlobalPropertiesVersionIdQuery(platformKey), Long.class);
-    }
-
-    public List<ValuedPropertyView> getGlobalProperties(final Platform.Key platformKey) {
+    public List<ValuedPropertyView> getGlobalProperties(Platform.Key platformKey) {
         return querySyncList(new GetGlobalPropertiesQuery(platformKey), ValuedPropertyView.class);
     }
 

--- a/core/domain/src/main/kotlin/org/hesperides/core/domain/platforms/Platform.kt
+++ b/core/domain/src/main/kotlin/org/hesperides/core/domain/platforms/Platform.kt
@@ -42,8 +42,6 @@ data class GetPlatformsUsingModuleQuery(val moduleKey: Module.Key)
 class GetApplicationNamesQuery
 data class SearchApplicationsQuery(val applicationName: String)
 data class SearchPlatformsQuery(val applicationName: String, val platformName: String? = null)
-data class GetPropertiesVersionIdQuery(val platformId: String, val propertiesPath: String, val timestamp: Long) // timestamp == -1 => no timestamp
-data class GetGlobalPropertiesVersionIdQuery(val platformKey: Platform.Key)
 data class GetGlobalPropertiesQuery(val platformKey: Platform.Key)
 data class GetInstancesModelQuery(val platformKey: Platform.Key, val propertiesPath: String)
 data class InstanceExistsQuery(val platformKey: Platform.Key, val propertiesPath: String, val instanceName: String)

--- a/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/PropertiesController.java
+++ b/core/presentation/src/main/java/org/hesperides/core/presentation/controllers/PropertiesController.java
@@ -47,12 +47,12 @@ public class PropertiesController extends AbstractController {
     @ApiOperation("Get properties with the given path in a platform")
     @GetMapping("/{application_name}/platforms/{platform_name}/properties")
     public ResponseEntity getValuedProperties(Authentication authentication,
-                                              @PathVariable("application_name") final String applicationName,
-                                              @PathVariable("platform_name") final String platformName,
-                                              @RequestParam("path") final String propertiesPath,
+                                              @PathVariable("application_name") String applicationName,
+                                              @PathVariable("platform_name") String platformName,
+                                              @RequestParam("path") String propertiesPath,
                                               @ApiParam(value = "En milliseconds depuis l'EPOCH. Pour le générer via Javascript à partir d'une date: new Date('2019-01-01 12:00:00').getTime()")
-                                                  @RequestParam(value = "timestamp", required = false) final Long timestamp,
-                                              @RequestParam(value = "with_details", required = false) final boolean withDetails) {
+                                              @RequestParam(value = "timestamp", required = false) Long timestamp,
+                                              @RequestParam(value = "with_details", required = false) boolean withDetails) {
         Platform.Key platformKey = new Platform.Key(applicationName, platformName);
         User authenticatedUser = new User(authentication);
 
@@ -74,9 +74,9 @@ public class PropertiesController extends AbstractController {
 
     @GetMapping("/{application_name}/platforms/{platform_name}/properties/instance_model")
     @ApiOperation("Get properties with the given path in a platform")
-    public ResponseEntity<InstancesModelOutput> getInstancesModel(@PathVariable("application_name") final String applicationName,
-                                                                  @PathVariable("platform_name") final String platform_name,
-                                                                  @RequestParam("path") final String propertiesPath) {
+    public ResponseEntity<InstancesModelOutput> getInstancesModel(@PathVariable("application_name") String applicationName,
+                                                                  @PathVariable("platform_name") String platform_name,
+                                                                  @RequestParam("path") String propertiesPath) {
 
         Platform.Key platformKey = new Platform.Key(applicationName, platform_name);
         List<String> instancesModelView = platformUseCases.getInstancesModel(platformKey, propertiesPath);
@@ -88,12 +88,12 @@ public class PropertiesController extends AbstractController {
     @ApiOperation("Deprecated - Use PUT /{application_name}/platforms/{platform_name}/properties instead")
     @PostMapping("/{application_name}/platforms/{platform_name}/properties")
     public ResponseEntity<PropertiesIO> saveProperties(Authentication authentication,
-                                                       @PathVariable("application_name") final String applicationName,
-                                                       @PathVariable("platform_name") final String platformName,
-                                                       @RequestParam("path") final String propertiesPath,
-                                                       @RequestParam("platform_vid") final Long platformVersionId,
-                                                       @RequestParam(value = "comment", required = false) final String userComment,
-                                                       @Valid @RequestBody final PropertiesIO properties) {
+                                                       @PathVariable("application_name") String applicationName,
+                                                       @PathVariable("platform_name") String platformName,
+                                                       @RequestParam("path") String propertiesPath,
+                                                       @RequestParam("platform_vid") Long platformVersionId,
+                                                       @RequestParam(value = "comment", required = false) String userComment,
+                                                       @Valid @RequestBody PropertiesIO properties) {
         return ResponseEntity.ok()
                 .header("Deprecation", "version=\"2019-08-02\"")
                 .header("Sunset", "Sat Aug  3 00:00:00 CEST 2020")
@@ -111,12 +111,12 @@ public class PropertiesController extends AbstractController {
     @ApiOperation("Update deployed modules or global properties")
     @PutMapping("/{application_name}/platforms/{platform_name}/properties")
     public ResponseEntity<PropertiesIO> updateProperties(Authentication authentication,
-                                                         @PathVariable("application_name") final String applicationName,
-                                                         @PathVariable("platform_name") final String platformName,
-                                                         @RequestParam("path") final String propertiesPath,
-                                                         @RequestParam("platform_vid") final Long platformVersionId,
-                                                         @RequestParam(value = "comment", required = false) final String userComment,
-                                                         @Valid @RequestBody final PropertiesIO properties) {
+                                                         @PathVariable("application_name") String applicationName,
+                                                         @PathVariable("platform_name") String platformName,
+                                                         @RequestParam("path") String propertiesPath,
+                                                         @RequestParam("platform_vid") Long platformVersionId,
+                                                         @RequestParam(value = "comment", required = false) String userComment,
+                                                         @Valid @RequestBody PropertiesIO properties) {
 
         List<AbstractValuedProperty> abstractValuedProperties = properties.toDomainInstances();
         Platform.Key platformKey = new Platform.Key(applicationName, platformName);
@@ -129,7 +129,7 @@ public class PropertiesController extends AbstractController {
                 properties.getPropertiesVersionId(),
                 userComment,
                 new User(authentication));
-        Long propertiesVersionId = platformUseCases.getPropertiesVersionId(platformKey, propertiesPath);
+        Long propertiesVersionId = platformUseCases.getPropertiesVersionId(platformKey, propertiesPath, null);
         return ResponseEntity.ok(new PropertiesIO(propertiesVersionId, propertyViews));
     }
 
@@ -157,17 +157,17 @@ public class PropertiesController extends AbstractController {
     @ApiOperation("Get properties diff with the given paths in given platforms")
     @GetMapping("/{application_name}/platforms/{platform_name}/properties/diff")
     public ResponseEntity<PropertiesDiffOutput> getPropertiesDiff(Authentication authentication,
-                                                                  @PathVariable("application_name") final String fromApplicationName,
-                                                                  @PathVariable("platform_name") final String fromPlatformName,
-                                                                  @RequestParam("path") final String fromPropertiesPath,
-                                                                  @RequestParam(value = "instance_name", required = false, defaultValue = "") final String fromInstanceName,
-                                                                  @RequestParam("to_application") final String toApplicationName,
-                                                                  @RequestParam("to_platform") final String toPlatformName,
-                                                                  @RequestParam("to_path") final String toPropertiesPath,
-                                                                  @RequestParam(value = "to_instance_name", required = false, defaultValue = "") final String toInstanceName,
-                                                                  @RequestParam(value = "compare_stored_values", required = false) final boolean compareStoredValues,
+                                                                  @PathVariable("application_name") String fromApplicationName,
+                                                                  @PathVariable("platform_name") String fromPlatformName,
+                                                                  @RequestParam("path") String fromPropertiesPath,
+                                                                  @RequestParam(value = "instance_name", required = false, defaultValue = "") String fromInstanceName,
+                                                                  @RequestParam("to_application") String toApplicationName,
+                                                                  @RequestParam("to_platform") String toPlatformName,
+                                                                  @RequestParam("to_path") String toPropertiesPath,
+                                                                  @RequestParam(value = "to_instance_name", required = false, defaultValue = "") String toInstanceName,
+                                                                  @RequestParam(value = "compare_stored_values", required = false) boolean compareStoredValues,
                                                                   @ApiParam(value = "En milliseconds depuis l'EPOCH. Pour le générer via Javascript à partir d'une date: new Date('2019-01-01 12:00:00').getTime()")
-                                                                  @RequestParam(value = "timestamp", required = false) final Long timestamp) {
+                                                                  @RequestParam(value = "timestamp", required = false) Long timestamp) {
         Platform.Key fromPlatformKey = new Platform.Key(fromApplicationName, fromPlatformName);
         Platform.Key toPlatformKey = new Platform.Key(toApplicationName, toPlatformName);
 
@@ -181,8 +181,8 @@ public class PropertiesController extends AbstractController {
 
     @ApiOperation("List all platform global properties usage")
     @GetMapping("/{application_name}/platforms/{platform_name}/global_properties_usage")
-    public ResponseEntity<Map<String, Set<GlobalPropertyUsageOutput>>> getGlobalPropertiesUsage(@PathVariable("application_name") final String applicationName,
-                                                                                                @PathVariable("platform_name") final String platformName) {
+    public ResponseEntity<Map<String, Set<GlobalPropertyUsageOutput>>> getGlobalPropertiesUsage(@PathVariable("application_name") String applicationName,
+                                                                                                @PathVariable("platform_name") String platformName) {
 
         Map<String, Set<GlobalPropertyUsageView>> globalPropertyUsageView = platformUseCases.getGlobalPropertiesUsage(new Platform.Key(applicationName, platformName));
 

--- a/tests/bdd/src/test/resources/platforms/properties/get-properties.feature
+++ b/tests/bdd/src/test/resources/platforms/properties/get-properties.feature
@@ -28,7 +28,7 @@ Feature: Get properties
     And an existing module with properties
     And an existing platform with this module and valued properties
     When I try to get the platform properties for this module with an invalid version type
-    Then the request is rejected with a bad request error
+    Then the resource is not found
 
   Scenario: get platform global properties
     Given an existing platform with global properties


### PR DESCRIPTION
Je n'ai pas fait de test BDD car il n'est pas possible de reproduire le cas via des tests fonctionnels. J'ai donc ajouté des tests unitaires.