### PR TITLE
Fix #840: Correction du log d'évènement de mise à jour de plateforme

### DIFF
--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/commands/PlatformAggregate.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/commands/PlatformAggregate.java
@@ -170,10 +170,10 @@ public class PlatformAggregate implements Serializable {
     @EventSourcingHandler
     public void onPlatformCreatedEvent(PlatformCreatedEvent event) {
         log.debug("onPlatformCreatedEvent - platformId: {} - key: {} - versionId: {} - user: {}",
-                event.getPlatformId(), event.getPlatformKey(), event.getPlatform().getVersionId(), event.getUser());
+                event.getPlatformId(), event.getPlatform().getKey(), event.getPlatform().getVersionId(), event.getUser());
         logAfterEventVersionId(event.getPlatform().getVersionId());
         this.id = event.getPlatformId();
-        this.key = event.getPlatformKey();
+        this.key = event.getPlatform().getKey();
         this.versionId = event.getPlatform().getVersionId();
     }
 

--- a/core/domain/src/main/java/org/hesperides/core/domain/platforms/commands/PlatformAggregate.java
+++ b/core/domain/src/main/java/org/hesperides/core/domain/platforms/commands/PlatformAggregate.java
@@ -179,8 +179,8 @@ public class PlatformAggregate implements Serializable {
 
     @EventSourcingHandler
     public void onPlatformUpdatedEvent(PlatformUpdatedEvent event) {
-        log.debug("onPlatformCreatedEvent - platformId: {} - key: {} - versionId: {} - user: {}",
-                event.getPlatformId(), event.getPlatformKey(), event.getPlatform().getVersionId(), event.getUser());
+        log.debug("onPlatformUpdatedEvent - platformId: {} - key: {} - versionId: {} - user: {}",
+                event.getPlatformId(), event.getPlatform().getKey(), event.getPlatform().getVersionId(), event.getUser());
         logAfterEventVersionId(event.getPlatform().getVersionId());
         this.versionId = event.getPlatform().getVersionId();
     }

--- a/core/domain/src/main/kotlin/org/hesperides/core/domain/platforms/Platform.kt
+++ b/core/domain/src/main/kotlin/org/hesperides/core/domain/platforms/Platform.kt
@@ -19,15 +19,12 @@ data class RestoreDeletedPlatformCommand(@TargetAggregateIdentifier val platform
 
 // Event
 
-open class PlatformEvent(@Transient open val platformId: String, @Transient override val user: String) : UserEvent(user)
-open class PlatformEventWithKey(@Transient open val platformKey: Platform.Key, @Transient override val platformId: String, @Transient override val user: String) : PlatformEvent(platformId, user)
-
-data class PlatformCreatedEvent(override val platformId: String, val platform: Platform, override val user: String) : PlatformEventWithKey(platform.key, platformId, user)
-data class PlatformUpdatedEvent(override val platformId: String, val platform: Platform, val copyPropertiesForUpgradedModules: Boolean, override val user: String) : PlatformEventWithKey(platform.key, platformId, user)
-data class PlatformDeletedEvent(override val platformId: String, override val platformKey: Platform.Key, override val user: String) : PlatformEventWithKey(platformKey, platformId, user)
-data class PlatformPropertiesUpdatedEvent(override val platformId: String, val platformVersionId: Long, val globalPropertiesVersionId: Long, val valuedProperties: List<ValuedProperty>, override val user: String) : PlatformEvent(platformId, user)
-data class PlatformModulePropertiesUpdatedEvent(override val platformId: String, val propertiesPath: String, val platformVersionId: Long, val propertiesVersionId: Long, val valuedProperties: List<AbstractValuedProperty>, val userComment: String, override val user: String) : PlatformEvent(platformId, user)
-data class RestoreDeletedPlatformEvent(override val platformId: String, override val user: String) : PlatformEvent(platformId, user)
+data class PlatformCreatedEvent(val platformId: String, val platform: Platform, override val user: String) : UserEvent(user)
+data class PlatformUpdatedEvent(val platformId: String, val platform: Platform, val copyPropertiesForUpgradedModules: Boolean, override val user: String) : UserEvent(user)
+data class PlatformDeletedEvent(val platformId: String, val platformKey: Platform.Key, override val user: String) : UserEvent(user)
+data class PlatformPropertiesUpdatedEvent(val platformId: String, val platformVersionId: Long, val globalPropertiesVersionId: Long, val valuedProperties: List<ValuedProperty>, override val user: String) : UserEvent(user)
+data class PlatformModulePropertiesUpdatedEvent(val platformId: String, val propertiesPath: String, val platformVersionId: Long, val propertiesVersionId: Long, val valuedProperties: List<AbstractValuedProperty>, val userComment: String, override val user: String) : UserEvent(user)
+data class RestoreDeletedPlatformEvent(val platformId: String, override val user: String) : UserEvent(user)
 
 // Query
 

--- a/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/platforms/MongoPlatformProjectionRepository.java
+++ b/core/infrastructure/src/main/java/org/hesperides/core/infrastructure/mongo/platforms/MongoPlatformProjectionRepository.java
@@ -257,7 +257,7 @@ public class MongoPlatformProjectionRepository implements PlatformProjectionRepo
                 .filter(msg -> PlatformAggregate.class.getSimpleName().equals(msg.getType()))
                 .map(MessageDecorator::getPayload)
                 // On part du principe qu'une plateforme à restaurer a forcément été supprimée,
-                // on peut donc n'effectuer la recherche que le évènement `PlatformDeletedEvent`
+                // on peut donc n'effectuer la recherche que sur l'évènement `PlatformDeletedEvent`
                 .filter(PlatformDeletedEvent.class::isInstance)
                 .map(PlatformDeletedEvent.class::cast)
                 .filter(platformEvent -> platformEvent.getPlatformKey().getApplicationName().equalsIgnoreCase(query.getPlatformKey().getApplicationName()) &&


### PR DESCRIPTION
Cela corrige mais n'explique pas pourquoi `event.getPlatformKey()` est à `null`